### PR TITLE
[Feat] Use Swagger for API docs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,12 +28,21 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	implementation('javax.xml.bind:jaxb-api')
-	implementation('io.jsonwebtoken:jjwt-api:0.11.2')
-	implementation('io.jsonwebtoken:jjwt-impl:0.11.2')
-	implementation('io.jsonwebtoken:jjwt-jackson:0.11.2')
+	implementation('io.jsonwebtoken:jjwt-api:0.11.5')
+	implementation('io.jsonwebtoken:jjwt-impl:0.11.5')
+	implementation('io.jsonwebtoken:jjwt-jackson:0.11.5')
 
-	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.3.1'
+	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.1'
 
+	// Security, Authentication
+	implementation ('org.springframework.boot:spring-boot-starter-security')
+	implementation ('org.springframework.boot:spring-boot-starter-validation')
+
+	// Oauth2
+	implementation ('org.springframework.boot:spring-boot-starter-oauth2-client:2.7.0')
+
+	// Swagger
+	implementation ('io.springfox:springfox-boot-starter:3.0.0')
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ms/umc/todoary/config/BaseResponseStatus.java
+++ b/src/main/java/com/ms/umc/todoary/config/BaseResponseStatus.java
@@ -28,7 +28,7 @@ public enum BaseResponseStatus {
     // [POST] /users
     POST_USERS_EMPTY_EMAIL(false, 2015, "이메일을 입력해주세요."),
     POST_USERS_INVALID_EMAIL(false, 2016, "이메일 형식을 확인해주세요."),
-    POST_USERS_EXISTS_EMAIL(false,2017,"중복된 이`메일입니다."),
+    POST_USERS_EXISTS_EMAIL(false,2017,"중복된 이메일입니다."),
 
     POST_POSTS_INVALID_CONTENTS(false, 2018, "제한 글자 수를 초과하였습니다."),
     POST_POSTS_EMPTY_IMGURL(false, 2019, "게시물의 이미지를 입력해주세요."),

--- a/src/main/java/com/ms/umc/todoary/config/SecurityConfig.java
+++ b/src/main/java/com/ms/umc/todoary/config/SecurityConfig.java
@@ -1,0 +1,71 @@
+package com.ms.umc.todoary.config;
+
+import com.ms.umc.todoary.utils.JwtService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity // Spring Security 필터를 스프링 필터체인에 등록
+public class SecurityConfig {
+    private final JwtService jwtService;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+
+
+    @Autowired
+    public SecurityConfig(JwtService jwtService, AuthenticationManagerBuilder authenticationManagerBuilder) {
+        this.jwtService = jwtService;
+        this.authenticationManagerBuilder = authenticationManagerBuilder;
+    }
+
+    @Bean
+    public SecurityFilterChain apiFilterChain(HttpSecurity http) throws Exception {
+        AuthenticationManager authenticationManager = http.getSharedObject(AuthenticationManager.class);
+        http.csrf().disable() // 세션 사용 안하므로
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 세션 사용 안함
+                .and()
+                .formLogin().disable() // form 태그 만들어서 로그인을 안함
+                .httpBasic().disable() // 기본 방식 안쓰고 Bearer(jwt) 방법 사용할 것
+                .authorizeRequests()
+                .antMatchers("/auth/**").permitAll()
+                .antMatchers("/oauth2/**").permitAll()
+                // swagger
+                .antMatchers("/swagger-ui/**").permitAll()
+                .antMatchers("/swagger-ui.html").permitAll()
+                .antMatchers("/swagger/**").permitAll()
+                .antMatchers("/swagger-resources/**").permitAll()
+                .antMatchers("/v2/api-docs").permitAll()
+                .antMatchers("/health").permitAll()
+                .and()
+                .authorizeRequests()
+                .anyRequest().authenticated();
+
+        return http.build();
+    }
+
+    /**
+     * resource 에는 security 적용 안함
+     *
+     * @param http
+     * @return
+     * @throws Exception
+     */
+    @Bean
+    @Order(0)
+    public SecurityFilterChain resources(HttpSecurity http) throws Exception {
+        http
+                .requestMatchers(matchers -> matchers.antMatchers("/resources/**"))
+                .authorizeHttpRequests((authorize) -> authorize.anyRequest().permitAll())
+                .requestCache().disable()
+                .securityContext().disable()
+                .sessionManagement().disable();
+        return http.build();
+    }
+}

--- a/src/main/java/com/ms/umc/todoary/config/SwaggerConfig.java
+++ b/src/main/java/com/ms/umc/todoary/config/SwaggerConfig.java
@@ -1,0 +1,76 @@
+package com.ms.umc.todoary.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ApiKey;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.SecurityReference;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
+import springfox.documentation.spring.web.plugins.Docket;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Configuration
+@EnableWebMvc
+public class SwaggerConfig {
+
+    private ApiInfo swaggerInfo() {
+        return new ApiInfoBuilder().title("Todoary API")
+                .description("Todoary API Docs").build();
+    }
+
+    @Bean
+    public Docket swaggerApi() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .consumes(getConsumeContentTypes())
+                .produces(getProduceContentTypes())
+                .apiInfo(swaggerInfo())
+                .securityContexts(Arrays.asList(securityContext()))
+                .securitySchemes(Arrays.asList(apiKey()))
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.ms.umc.todoary.src"))
+                .paths(PathSelectors.any())
+                .build()
+                .useDefaultResponseMessages(false);
+    }
+
+    private ApiKey apiKey() {
+        return new ApiKey("JWT", "Authorization", "header");
+    }
+
+    private SecurityContext securityContext() {
+        return SecurityContext.builder()
+                .securityReferences(defaultAuth())
+                .build();
+    }
+
+    List<SecurityReference> defaultAuth() {
+        AuthorizationScope authorizationScope
+                = new AuthorizationScope("global", "accessEverything");
+        AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+        authorizationScopes[0] = authorizationScope;
+        return Arrays.asList(new SecurityReference("JWT", authorizationScopes));
+    }
+
+    private Set<String> getConsumeContentTypes() {
+        Set<String> consumes = new HashSet<>();
+        consumes.add("application/json;charset=UTF-8");
+        consumes.add("application/x-www-form-urlencoded");
+        return consumes;
+    }
+
+    private Set<String> getProduceContentTypes() {
+        Set<String> produces = new HashSet<>();
+        produces.add("application/json;charset=UTF-8");
+        return produces;
+    }
+}


### PR DESCRIPTION
# [Swagger](https://swagger.io/)
API docs 작성할 때나 테스트할 때 편할 것 같아서 추가해봤습니다.

**지정된 패키지에 있는 RestController의 api들을 읽어서** 브라우저에서 테스트할 수 있게 해줍니다.

## 설정
- 패키지 지정은 `SwaggerConfig` 클래스에서 할 수 있습니다.
- 현재는 basePackage가 `com.ms.umc.todoary.src`로 되어 있어서 소스 파일 내의 모든 Controller가 나옵니다.

## 테스트 페이지 링크
스프링 App 실행 후에 
- http://localhost:9000/swagger-ui/index.html 

위 링크로 접속하면 아래와 같은 화면이 나와서 테스트 해볼 수 있습니다.
![image](https://user-images.githubusercontent.com/101321313/179356727-400e2ce7-a429-43c3-a51d-0c38e45b34cd.png)

## Token
- access token이 필요한 api들은 아래 자물쇠를 클릭하여 token 값을 입력하면 header에 해당 token 값이 추가되어 요청을 보낼 수 있게 됩니다.
![image](https://user-images.githubusercontent.com/101321313/179356992-c967fd86-8366-4e70-bb1d-13d2793ff40a.png) ![image](https://user-images.githubusercontent.com/101321313/179357005-36f14fda-c1d0-4402-9a0e-558e41e6aed0.png)


