### PR TITLE
[Feat] Return user new or not when oauth2 sign in

### DIFF
--- a/src/main/java/com/todoary/ms/src/auth/AuthController.java
+++ b/src/main/java/com/todoary/ms/src/auth/AuthController.java
@@ -10,6 +10,7 @@ import com.todoary.ms.src.user.dto.PostUserReq;
 import com.todoary.ms.src.user.model.User;
 import com.todoary.ms.util.BaseException;
 import com.todoary.ms.util.BaseResponse;
+import com.todoary.ms.util.BaseResponseStatus;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,7 +66,7 @@ public class AuthController {
             String encodedPassword = passwordEncoder.encode(postUserReq.getPassword());
             User user = new User(postUserReq.getUsername(), postUserReq.getNickname(), postUserReq.getEmail(), encodedPassword, "ROLE_USER", "none", "none");
             userService.createUser(user);
-            return new BaseResponse("회원가입에 성공했습니다.");
+            return new BaseResponse<>(BaseResponseStatus.SUCCESS);
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }

--- a/src/main/java/com/todoary/ms/src/auth/AuthController.java
+++ b/src/main/java/com/todoary/ms/src/auth/AuthController.java
@@ -52,10 +52,10 @@ public class AuthController {
     }
 
     @GetMapping("/login/success")
-    public BaseResponse<PostLoginRes> loginSuccess(@RequestParam("accessToken") String accessToken, @RequestParam("refreshToken") String refreshToken) {
+    public BaseResponse<PostLoginRes> oauth2LoginSuccess(@RequestParam("isNew") boolean isNew, @RequestParam("accessToken") String accessToken, @RequestParam("refreshToken") String refreshToken) {
         Token token = new Token(accessToken, refreshToken);
 
-        PostLoginRes postLoginRes = new PostLoginRes(token);
+        PostLoginRes postLoginRes = new PostLoginRes(isNew, token);
         return new BaseResponse<>(postLoginRes);
     }
 

--- a/src/main/java/com/todoary/ms/src/auth/PrincipalOAuth2UserService.java
+++ b/src/main/java/com/todoary/ms/src/auth/PrincipalOAuth2UserService.java
@@ -56,9 +56,10 @@ public class PrincipalOAuth2UserService extends DefaultOAuth2UserService {
         String role = "ROLE_USER";
 
         try {
-            user = userProvider.retrieveByEmail(email);
+            if (userProvider.checkEmail(email, provider) == 1)
+                user = userProvider.retrieveByEmail(email, provider);
         } catch (BaseException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
         if (user == null) {
             System.out.println("구글 로그인 최초입니다. 회원가입을 진행합니다.");

--- a/src/main/java/com/todoary/ms/src/auth/PrincipalOAuth2UserService.java
+++ b/src/main/java/com/todoary/ms/src/auth/PrincipalOAuth2UserService.java
@@ -69,12 +69,12 @@ public class PrincipalOAuth2UserService extends DefaultOAuth2UserService {
             } catch (BaseException e) {
                 e.printStackTrace();
             }
-
+            return new PrincipalDetails(user, oAuth2User.getAttributes(), true);
         } else {
             System.out.println("구글 로그인 기록이 있습니다. 로그인을 진행합니다.");
+            return new PrincipalDetails(user, oAuth2User.getAttributes(), false);
         }
 
-        return new PrincipalDetails(user, oAuth2User.getAttributes());
     }
 
     private String generateRandomNickname() {

--- a/src/main/java/com/todoary/ms/src/auth/dto/PostLoginRes.java
+++ b/src/main/java/com/todoary/ms/src/auth/dto/PostLoginRes.java
@@ -1,5 +1,6 @@
 package com.todoary.ms.src.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.todoary.ms.src.auth.model.Token;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -7,5 +8,12 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class PostLoginRes {
+
+    @JsonProperty("isNew")
+    private boolean isNew = false;
     private Token token;
+
+    public PostLoginRes(Token token) {
+        this.token = token;
+    }
 }

--- a/src/main/java/com/todoary/ms/src/auth/jwt/config/OAuth2SuccessHandler.java
+++ b/src/main/java/com/todoary/ms/src/auth/jwt/config/OAuth2SuccessHandler.java
@@ -28,15 +28,25 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         String targetUrl;
 
-        String accessToken =  jwtTokenProvider.createAccessToken(oAuth2User.getUser().getId());
-        String refreshToken =  jwtTokenProvider.createRefreshToken(oAuth2User.getUser().getId());
+        String accessToken = jwtTokenProvider.createAccessToken(oAuth2User.getUser().getId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(oAuth2User.getUser().getId());
 
-        authService.registerRefreshToken(oAuth2User.getUser().getId(),refreshToken);
+        authService.registerRefreshToken(oAuth2User.getUser().getId(), refreshToken);
 
-        targetUrl = UriComponentsBuilder.fromUriString("/auth/login/success")
-                .queryParam("accessToken",accessToken)
-                .queryParam("refreshToken",refreshToken)
-                .build().toUriString();
+        // 새로 가입한 유저
+        if (oAuth2User.isNew()) {
+            targetUrl = UriComponentsBuilder.fromUriString("/auth/login/success")
+                    .queryParam("isNew", true)
+                    .queryParam("accessToken", accessToken)
+                    .queryParam("refreshToken", refreshToken)
+                    .build().toUriString();
+        } else { // 기존 유저
+            targetUrl = UriComponentsBuilder.fromUriString("/auth/login/success")
+                    .queryParam("isNew", false)
+                    .queryParam("accessToken", accessToken)
+                    .queryParam("refreshToken", refreshToken)
+                    .build().toUriString();
+        }
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 }

--- a/src/main/java/com/todoary/ms/src/auth/model/PrincipalDetails.java
+++ b/src/main/java/com/todoary/ms/src/auth/model/PrincipalDetails.java
@@ -16,13 +16,21 @@ public class PrincipalDetails implements UserDetails, OAuth2User {
     private User user;
     private Map<String, Object> attributes;
 
+    // 새로 가입시킨 유저인가
+    boolean isNew = false;
+
     public PrincipalDetails(User user) {
         this.user = user;
     }
 
-    public PrincipalDetails(User user, Map<String, Object> attributes) {
+    public PrincipalDetails(User user, Map<String, Object> attributes, boolean isNew) {
         this.user = user;
         this.attributes = attributes;
+        this.isNew = isNew;
+    }
+
+    public boolean isNew() {
+        return isNew;
     }
 
     @Override

--- a/src/main/java/com/todoary/ms/src/user/UserDao.java
+++ b/src/main/java/com/todoary/ms/src/user/UserDao.java
@@ -21,10 +21,9 @@ public class UserDao {
     }
 
 
-
     public User insertUser(User user) {
         String insertUserQuery = "insert into user (username,nickname,email,password,role,provider,provider_id) values (?,?,?,?,?,?,?)";
-        Object[] insertUserParams = new Object[]{user.getUsername(), user.getNickname(),user.getEmail(), user.getPassword(), user.getRole(),user.getProvider(),user.getProvider_id()};
+        Object[] insertUserParams = new Object[]{user.getUsername(), user.getNickname(), user.getEmail(), user.getPassword(), user.getRole(), user.getProvider(), user.getProvider_id()};
 
         this.jdbcTemplate.update(insertUserQuery, insertUserParams);
 
@@ -35,10 +34,9 @@ public class UserDao {
         return user;
     }
 
-    public User selectByEmail(String email) {
-
-        String selectByEmailQuery = "select id, username, nickname,email, password,profile_img_url, introduce, role, provider, provider_id from user where email = ? and status = 1";
-
+    public User selectByEmail(String email, String provider) {
+        String selectByEmailQuery = "select id, username, nickname,email, password,profile_img_url, introduce, role, provider, provider_id from user where email = ? and provider = ? and status = 1";
+        Object[] selectByEmailParams = new Object[]{email, provider};
         try {
             return this.jdbcTemplate.queryForObject(selectByEmailQuery,
                     (rs, rowNum) -> new User(
@@ -52,7 +50,7 @@ public class UserDao {
                             rs.getString("role"),
                             rs.getString("provider"),
                             rs.getString("provider_id")),
-                    email);
+                    selectByEmailParams);
         } catch (EmptyResultDataAccessException e) {
             return null;
         }
@@ -75,9 +73,10 @@ public class UserDao {
                 user_id);
     }
 
-    public int checkEmail(String email) {
-        String checkEmailQuery = "select exists(select email from user where email = ? and status = 1)";
-        return this.jdbcTemplate.queryForObject(checkEmailQuery,int.class,email);
+    public int checkEmail(String email, String provider) {
+        String checkEmailQuery = "select exists(select email, provider from user where email = ? and provider = ? and status = 1)";
+        Object[] checkEmailParams = new Object[]{email, provider};
+        return this.jdbcTemplate.queryForObject(checkEmailQuery, int.class, checkEmailParams);
     }
 
     public int checkNickname(String nickname) {

--- a/src/main/java/com/todoary/ms/src/user/UserProvider.java
+++ b/src/main/java/com/todoary/ms/src/user/UserProvider.java
@@ -19,11 +19,22 @@ public class UserProvider {
         this.userDao = userDao;
     }
 
-    public User retrieveByEmail(String email) throws BaseException {
-        if (checkEmail(email) == 0)
+    /**
+     * 기본적으로 email로 유저를 확인할 때는 항상 provider와 같이 확인해야 한다.
+     * email을 이용하여 확인할 때 provider 파라미터가 주어지지 않는다면
+     * 일반 회원가입한 유저(provider=="none")를 가져오게 된다.
+     * @param email
+     * @return User
+     * @throws BaseException
+     */
+    public User retrieveByEmail(String email) throws BaseException{
+        return retrieveByEmail(email, "none");
+    }
+    public User retrieveByEmail(String email, String provider) throws BaseException {
+        if (checkEmail(email, provider) == 0)
             throw new BaseException(USERS_EMPTY_USER_EMAIL);
         try {
-            return userDao.selectByEmail(email);
+            return userDao.selectByEmail(email, provider);
         } catch (Exception e) {
             throw new BaseException(DATABASE_ERROR);
         }
@@ -40,9 +51,20 @@ public class UserProvider {
         }
     }
 
+    /**
+     * 기본적으로 email로 유저를 확인할 때는 항상 provider와 같이 확인해야 한다.
+     * email을 이용하여 확인할 때 provider 파라미터가 주어지지 않는다면
+     * 일반 회원가입한 유저(provider=="none")가 있는 지 체크하게 된다.
+     * @param email
+     * @return int 0 or 1
+     * @throws BaseException
+     */
     public int checkEmail(String email) throws BaseException {
+        return checkEmail(email, "none");
+    }
+    public int checkEmail(String email, String provider) throws BaseException {
         try {
-            return userDao.checkEmail(email);
+            return userDao.checkEmail(email, provider);
         } catch (Exception exception) {
             log.warn(exception.getMessage());
             throw new BaseException(DATABASE_ERROR);

--- a/src/main/java/com/todoary/ms/src/user/UserService.java
+++ b/src/main/java/com/todoary/ms/src/user/UserService.java
@@ -9,8 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import static com.todoary.ms.util.BaseResponseStatus.DATABASE_ERROR;
-import static com.todoary.ms.util.BaseResponseStatus.USERS_EMPTY_USER_ID;
+import static com.todoary.ms.util.BaseResponseStatus.*;
 
 @Slf4j
 @Service
@@ -26,6 +25,12 @@ public class UserService {
     }
 
     public User createUser(User user) throws BaseException {
+        if (userProvider.checkEmail(user.getEmail(), user.getProvider()) == 1) {
+            throw new BaseException(POST_USERS_EXISTS_EMAIL);
+        }
+        if (userProvider.checkNickname(user.getNickname()) == 1) {
+            throw new BaseException(POST_USERS_EXISTS_NICKNAME);
+        }
         try {
             return this.userDao.insertUser(user);
         } catch (Exception e) {
@@ -56,9 +61,9 @@ public class UserService {
     public void removeUser(Long user_id) throws BaseException {
         if (userProvider.checkId(user_id) == 0)
             throw new BaseException(USERS_EMPTY_USER_ID);
-        try{
+        try {
             userDao.updateUserStatus(user_id);
-        }catch(Exception e){
+        } catch (Exception e) {
             e.printStackTrace();
             throw new BaseException(DATABASE_ERROR);
         }

--- a/src/main/java/com/todoary/ms/util/BaseResponseStatus.java
+++ b/src/main/java/com/todoary/ms/util/BaseResponseStatus.java
@@ -22,7 +22,7 @@ public enum BaseResponseStatus {
     INVALID_JWT(false, 2002, "유효하지 않은 JWT입니다."),
     EXPIRED_JWT(false, 2003, "만료된 JWT입니다."),
     INVALID_USER_JWT(false,2004,"권한이 없는 유저의 접근입니다."),
-    INVALID_AUTH(false, 2005, "유효하지 않은 JWT입니다."),
+    INVALID_AUTH(false, 2005, "유효하지 않은 회원 정보입니다."),
 
     // users
     USERS_EMPTY_USER_ID(false, 2010, "유저 아이디 값을 확인해주세요."),
@@ -40,7 +40,7 @@ public enum BaseResponseStatus {
     POST_USERS_EMPTY_PASSWORD(false, 2030, "비밀번호를 입력해주세요."),
     POST_USERS_INVALID_PASSWORD(false, 2031, "비밀번호 형식을 확인해주세요."),
 
-
+    POST_USERS_EXISTS_NICKNAME(false, 2032, "중복된 닉네임입니다."),
     /**
      * 3000 : Response 오류
      */


### PR DESCRIPTION
- [X] 기존에는 구글 로그인 후 클라이언트에 응답할 때, 새로 회원가입한 유저나 이미 가입된 유저나 구분이 되지 않고 있었습니다. 두 경우를 구분해야할 것 같아서 구분하여 응답하도록 수정했습니다.
- [X] 지난 번 회의에서 이메일이 같아도 일반/apple/google에 따라서 모두 새 계정을 쓸 수 있도록 하자고 결정되었으므로, 이메일로 확인하는 모든 곳에서 provider도 같이 확인하여 email, provider가 모두 같아야 같은 user로 판단하도록 수정했습니다.
- [X] 그 밖에 명세서와 다른 응답 명세서에 맞도록 수정하고, 회원가입 시 이미 있는 닉네임인지 먼저 체크하는 로직 추가했습니다.