### PR TITLE
[Fix] Modify variable name to fit api docs

### DIFF
--- a/src/main/java/com/todoary/ms/src/auth/dto/PostAccessRes.java
+++ b/src/main/java/com/todoary/ms/src/auth/dto/PostAccessRes.java
@@ -7,5 +7,5 @@ import lombok.RequiredArgsConstructor;
 @Data
 @RequiredArgsConstructor
 public class PostAccessRes {
-    private final Token refreshToken;
+    private final Token token;
 }


### PR DESCRIPTION
 - [X] 토큰 재발급 시 변수명이 명세서와 다르게 되어 있던 것 명세서에 맞도록 수정