### PR TITLE
[Fix] Resolve refresh token using refresh key

### DIFF
--- a/src/main/java/com/todoary/ms/src/auth/AuthService.java
+++ b/src/main/java/com/todoary/ms/src/auth/AuthService.java
@@ -20,10 +20,10 @@ public class AuthService {
     }
 
     public Long registerRefreshToken(Long userid, String refreshToken) {
-        if(authDao.checkUser(userid))
+        if (authDao.checkUser(userid))
             authDao.updateRefreshToken(userid, refreshToken);
         else
-            authDao.insertRefreshToken(userid,refreshToken);
+            authDao.insertRefreshToken(userid, refreshToken);
 
         return userid;
     }
@@ -34,16 +34,18 @@ public class AuthService {
 //        return userid;
 //    }
 
-    public Token createAccess(String refreshToken) throws BaseException {
+    public Token registerNewTokenFromRefreshToken(String refreshToken) throws BaseException {
+        Long userId = Long.parseLong(jwtTokenProvider.getUserIdFromRefreshToken(refreshToken));
+        return registerNewTokenForUser(userId);
+    }
 
-        Long userid = Long.parseLong(jwtTokenProvider.getUseridFromRef(refreshToken));
+    public Token registerNewTokenForUser(Long userId) throws BaseException {
+        String newAccessToken = jwtTokenProvider.createAccessToken(userId);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
 
-        String newAccessToken = jwtTokenProvider.createAccessToken(userid);
-        String newRefreshToken = jwtTokenProvider.createRefreshToken(userid);
-
-        try{
-            authDao.updateRefreshToken(userid, newRefreshToken);
-        }catch(Exception e){
+        try {
+            registerRefreshToken(userId, newRefreshToken);
+        } catch (Exception e) {
             e.printStackTrace();
             throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }

--- a/src/main/java/com/todoary/ms/src/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/todoary/ms/src/auth/jwt/JwtTokenProvider.java
@@ -85,17 +85,20 @@ public class JwtTokenProvider {
 //    }
 
     // 토큰에서 회원 정보 추출
-    public String getUseridFromAcs(String token) {
-        return Jwts.parserBuilder().setSigningKey(accessKey).build()
+    public String getUserIdFromAccessToken(String token) {
+        return getUserIdFromTokenUsingKey(token, accessKey);
+    }
+
+    public String getUserIdFromRefreshToken(String token) {
+        return getUserIdFromTokenUsingKey(token, refreshKey);
+    }
+
+    private String getUserIdFromTokenUsingKey(String token, Key key){
+        return Jwts.parserBuilder().setSigningKey(key).build()
                 .parseClaimsJws(token).getBody().getSubject();
     }
 
-    public String getUseridFromRef(String token) {
-        return Jwts.parserBuilder().setSigningKey(accessKey).build()
-                .parseClaimsJws(token).getBody().getSubject();
-    }
-
-    public Long getExpiration(String accessToken) {
+    public Long getExpirationOfAccessToken(String accessToken) {
         // accessToken 남은 유효시간
         Date expiration = Jwts.parserBuilder().setSigningKey(accessKey).build().parseClaimsJws(accessToken).getBody().getExpiration();
         // 현재 시간

--- a/src/main/java/com/todoary/ms/src/auth/jwt/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/todoary/ms/src/auth/jwt/filter/JwtAuthorizationFilter.java
@@ -51,7 +51,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
                         .parserBuilder().setSigningKey(jwtTokenProvider.getAccessKey()).build()
                         .parseClaimsJws(jwtHeader);
 
-                Long user_id = Long.parseLong(jwtTokenProvider.getUseridFromAcs(jwtHeader));
+                Long user_id = Long.parseLong(jwtTokenProvider.getUserIdFromAccessToken(jwtHeader));
 //                log.info("인증 완료, uri: " + requestUri + " 인증 정보: " + authentication.getName());
 
 


### PR DESCRIPTION
## Refresh Token 재발급 시에 500 에러

전에 Refresh Token 관련해서 refreshKey가 아니라 accessKey를 쓰고 있어서 수정해주셨는데, JwtTokenProvider에서 Refresh Token을 읽어오는 함수에서 accessKey를 잘못 사용 하고 있는 부분이 남아 있어서 발생했던 문제입니다

1. 기존 코드 

    ```java
    public String getUseridFromAcs(String token) {
        return Jwts.parserBuilder().setSigningKey(accessKey).build()
                .parseClaimsJws(token).getBody().getSubject();
    }
    
    // 여긴 refreshKey여야함
    public String getUseridFromRef(String token) {
        return Jwts.parserBuilder().setSigningKey(accessKey).build()
                .parseClaimsJws(token).getBody().getSubject();
    }
    ```
2. 수정
따라서 refreshKey를 사용하도록 변경했고, 변경하면서 이름이 축약되어 있어서 헷갈릴 수 있을 것 같아서 함수 이름 변경 등 리팩터링도 추가로 진행했습니다.

    ```java
    public String getUserIdFromAccessToken(String token) {
        return getUserIdFromTokenUsingKey(token, accessKey);
    }
    
    public String getUserIdFromRefreshToken(String token) {
        return getUserIdFromTokenUsingKey(token, refreshKey);
    }
    
    private String getUserIdFromTokenUsingKey(String token, Key key){
        return Jwts.parserBuilder().setSigningKey(key).build()
                .parseClaimsJws(token).getBody().getSubject();
    }
    ```

+ 그 밖에도 토큰 재발급과 자동로그인에서 새로운 토큰 만들어서 등록하는 코드가 같은 로직인데 흩어져 있어서 함수로 만들어서 공통으로 사용하게 했습니다.