### PR TITLE
[Feat] Send slack alarm when write error log

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 	// FireBase
 	implementation 'com.google.firebase:firebase-admin:7.1.1'
 	implementation group : 'com.squareup.okhttp3', name : 'okhttp', version : '4.2.2'
+
+	// Slack
+	implementation 'com.github.maricn:logback-slack-appender:1.4.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/todoary/ms/src/alarm/AlarmController.java
+++ b/src/main/java/com/todoary/ms/src/alarm/AlarmController.java
@@ -2,19 +2,20 @@ package com.todoary.ms.src.alarm;
 
 import com.todoary.ms.src.alarm.dto.PostAlarmReq;
 import com.todoary.ms.src.alarm.model.Alarm;
-import com.todoary.ms.util.BaseException;
-import com.todoary.ms.util.BaseResponseStatus;
+import com.todoary.ms.util.ErrorLogWriter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
-
-import static com.todoary.ms.util.BaseResponseStatus.DATABASE_ERROR;
 
 @RestController
 @RequestMapping("/alarm")
@@ -30,19 +31,24 @@ public class AlarmController {
     }
 
     @PostMapping("/todo")
-    public ResponseEntity pushMessage(@RequestBody PostAlarmReq postAlarmReq) throws IOException {
+    public ResponseEntity pushMessage(@RequestBody PostAlarmReq postAlarmReq) {
         System.out.println(postAlarmReq.getTargetToken() + " "
                 + postAlarmReq.getTitle() + " " + postAlarmReq.getBody());
 
-        firebaseCloudMessageService.sendMessageTo(
-                postAlarmReq.getTargetToken(),
-                postAlarmReq.getTitle(),
-                postAlarmReq.getBody());
-        return ResponseEntity.ok().build();
+        try {
+            firebaseCloudMessageService.sendMessageTo(
+                    postAlarmReq.getTargetToken(),
+                    postAlarmReq.getTitle(),
+                    postAlarmReq.getBody());
+            return ResponseEntity.ok().build();
+        } catch (IOException e) {
+            ErrorLogWriter.writeExceptionWithMessage(e, "push message failed");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
     }
 
     @Scheduled(cron = "0 0/1 * 1/1 * ?")
-    public void TodoaryAlarm() throws IOException {
+    public void TodoaryAlarm() {
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm");
         String now = dateFormat.format(new Date());
 
@@ -52,50 +58,63 @@ public class AlarmController {
 
         List<Alarm> alarms_todo = alarmDao.selectByDateTime_todo(target_date, target_time);
         for (Alarm alarm : alarms_todo) {
-            firebaseCloudMessageService.sendMessageTo(
-                    alarm.getRegistration_token(),
-                    "Todoary 알림",
-                    alarm.getTitle());
+            try {
+                firebaseCloudMessageService.sendMessageTo(
+                        alarm.getRegistration_token(),
+                        "Todoary 알림",
+                        alarm.getTitle());
+            } catch (IOException e) {
+                ErrorLogWriter.writeExceptionWithMessage(e, "Todoary 알림 failed | " + alarm.toString());
+                throw new RuntimeException(e);
+            }
         }
     }
 
     @Scheduled(cron = "0 0 0 1/1 * ?")
-    public void DailyAlarm() throws IOException {
+    public void DailyAlarm(){
 
-        List<Alarm> alarms_daily =  alarmDao.selectByDateTime_daily();
+        List<Alarm> alarms_daily = alarmDao.selectByDateTime_daily();
         for (Alarm alarm : alarms_daily) {
-            firebaseCloudMessageService.sendMessageTo(
-                    alarm.getRegistration_token(),
-                    "하루기록 알림",
-                    "하루기록을 작성해보세요.");
+            try {
+                firebaseCloudMessageService.sendMessageTo(
+                        alarm.getRegistration_token(),
+                        "하루기록 알림",
+                        "하루기록을 작성해보세요.");
+            } catch (IOException e) {
+                ErrorLogWriter.writeExceptionWithMessage(e, "하루기록 알림 failed | " + alarm.toString());
+                throw new RuntimeException(e);
+            }
         }
 
     }
 
     @Scheduled(cron = "0 0 0 1/1 * ?")
-    public void RemindAlarm() throws IOException {
+    public void RemindAlarm() {
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
         String target_date = dateFormat.format(new Date());
 
         List<Alarm> alarms_remind = alarmDao.selectByDateTime_remind(target_date);
         for (Alarm alarm : alarms_remind) {
-            firebaseCloudMessageService.sendMessageTo(
-                    alarm.getRegistration_token(),
-                    "리마인드 알림",
-                    "하루기록을 작성한 지 일주일이 경과했습니다.");
+            try {
+                firebaseCloudMessageService.sendMessageTo(
+                        alarm.getRegistration_token(),
+                        "리마인드 알림",
+                        "하루기록을 작성한 지 일주일이 경과했습니다.");
+            } catch (IOException e) {
+                ErrorLogWriter.writeExceptionWithMessage(e, "리마인드 알림 failed | " + alarm.toString());
+                throw new RuntimeException(e);
+            }
         }
     }
 
     @Scheduled(cron = "0 0 ${fcm.secret.time} ? * ${fcm.secret.day}")
-    public void AlarmRemove() throws BaseException {
-
+    public void AlarmRemove(){
         try {
             alarmDao.deleteByDateTime_todo();
-        } catch(Exception e){
+        } catch (Exception e) {
+            ErrorLogWriter.writeExceptionWithMessage(e, "알람 삭제 failed");
             e.printStackTrace();
-            throw new BaseException(DATABASE_ERROR);
         }
-
     }
 
 }

--- a/src/main/java/com/todoary/ms/src/alarm/model/Alarm.java
+++ b/src/main/java/com/todoary/ms/src/alarm/model/Alarm.java
@@ -2,11 +2,11 @@ package com.todoary.ms.src.alarm.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-
-import java.util.Date;
+import lombok.ToString;
 
 @Data
 @AllArgsConstructor
+@ToString
 public class Alarm {
     private String registration_token;
     private String title;

--- a/src/main/java/com/todoary/ms/src/auth/jwt/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/todoary/ms/src/auth/jwt/config/CustomAuthenticationEntryPoint.java
@@ -1,15 +1,19 @@
 package com.todoary.ms.src.auth.jwt.config;
 
+import com.todoary.ms.util.BaseException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.util.StreamUtils;
 
-import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
-import static com.todoary.ms.util.BaseResponseStatus.*;
+import static com.todoary.ms.util.BaseResponseStatus.INVALID_AUTH;
+import static com.todoary.ms.util.ErrorLogWriter.writeExceptionWithRequest;
 
 /**
  * 유효하지 않은 JWT, 혹은 유저, 401 에러
@@ -17,8 +21,11 @@ import static com.todoary.ms.util.BaseResponseStatus.*;
 @Slf4j
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        log.info("401 ERROR");
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        ServletInputStream inputStream = request.getInputStream();
+        String messageBody = StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
+        writeExceptionWithRequest(new BaseException(INVALID_AUTH), request, messageBody);
+
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json;charset=UTF-8");
         response.getWriter().write("{" + "\"isSuccess\":false, "

--- a/src/main/java/com/todoary/ms/src/category/CategoryController.java
+++ b/src/main/java/com/todoary/ms/src/category/CategoryController.java
@@ -2,9 +2,7 @@ package com.todoary.ms.src.category;
 
 import com.todoary.ms.src.category.dto.GetCategoryRes;
 import com.todoary.ms.src.category.dto.PostCategoryReq;
-import com.todoary.ms.src.category.model.Category;
 import com.todoary.ms.src.category.dto.PostCategoryRes;
-import com.todoary.ms.src.todo.dto.PostTodoReq;
 import com.todoary.ms.util.BaseException;
 import com.todoary.ms.util.BaseResponse;
 import com.todoary.ms.util.BaseResponseStatus;
@@ -13,8 +11,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
 import java.util.List;
+
+import static com.todoary.ms.util.ErrorLogWriter.writeExceptionWithAuthorizedRequest;
 
 @Slf4j
 @RestController
@@ -44,7 +43,7 @@ public class CategoryController {
             Long categoryId = categoryService.createCategory(user_id, postCategoryReq);
             return new BaseResponse<>(new PostCategoryRes(categoryId));
         } catch (BaseException e) {
-            log.warn(e.getMessage());
+            writeExceptionWithAuthorizedRequest(e, request, postCategoryReq.toString());
             return new BaseResponse<>(e.getStatus());
         }
     }
@@ -66,7 +65,7 @@ public class CategoryController {
             categoryService.modifyCategory(user_id, categoryId, postCategoryReq);
             return new BaseResponse<>(BaseResponseStatus.SUCCESS);
         } catch (BaseException e) {
-            log.warn(e.getMessage());
+            writeExceptionWithAuthorizedRequest(e, request, postCategoryReq.toString());
             return new BaseResponse<>(e.getStatus());
         }
     }
@@ -85,6 +84,7 @@ public class CategoryController {
             Long user_id = Long.parseLong(request.getAttribute("user_id").toString());
             return new BaseResponse<>(categoryProvider.retrieveById(user_id));
         } catch (BaseException e) {
+            writeExceptionWithAuthorizedRequest(e, request);
             return new BaseResponse<>(e.getStatus());
         }
 
@@ -104,7 +104,7 @@ public class CategoryController {
             categoryService.removeCategory(user_id, categoryId);
             return new BaseResponse<>(BaseResponseStatus.SUCCESS);
         } catch (BaseException e) {
-            log.warn(e.getMessage());
+            writeExceptionWithAuthorizedRequest(e, request);
             return new BaseResponse<>(e.getStatus());
         }
     }

--- a/src/main/java/com/todoary/ms/src/diary/DiaryController.java
+++ b/src/main/java/com/todoary/ms/src/diary/DiaryController.java
@@ -2,7 +2,6 @@ package com.todoary.ms.src.diary;
 
 import com.todoary.ms.src.diary.dto.GetDiaryByDateRes;
 import com.todoary.ms.src.diary.dto.PostDiaryReq;
-import com.todoary.ms.src.diary.dto.PostDiaryRes;
 import com.todoary.ms.src.user.UserProvider;
 import com.todoary.ms.util.BaseException;
 import com.todoary.ms.util.BaseResponse;
@@ -13,6 +12,8 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
+
+import static com.todoary.ms.util.ErrorLogWriter.writeExceptionWithAuthorizedRequest;
 
 @Slf4j
 @RestController
@@ -46,7 +47,7 @@ public class DiaryController {
             diaryService.createOrModifyDiary(userId, postDiaryReq, createdDate);
             return new BaseResponse<>(BaseResponseStatus.SUCCESS);
         } catch (BaseException e) {
-            log.warn(e.getMessage());
+            writeExceptionWithAuthorizedRequest(e, request, postDiaryReq.toString());
             return new BaseResponse<>(e.getStatus());
         }
     }
@@ -63,7 +64,7 @@ public class DiaryController {
             diaryService.removeDiary(userId, createdDate);
             return new BaseResponse<>(BaseResponseStatus.SUCCESS);
         } catch (BaseException e) {
-            log.warn(e.getMessage());
+            writeExceptionWithAuthorizedRequest(e, request);
             return new BaseResponse<>(e.getStatus());
         }
     }
@@ -78,7 +79,7 @@ public class DiaryController {
             Long userId = getUserIdFromRequest(request);
             return new BaseResponse<>(diaryProvider.retrieveDiaryByDate(userId, created_at));
         } catch (BaseException e) {
-            log.warn(e.getMessage());
+            writeExceptionWithAuthorizedRequest(e, request);
             return new BaseResponse<>(e.getStatus());
         }
     }
@@ -93,7 +94,7 @@ public class DiaryController {
             Long userId = getUserIdFromRequest(request);
             return new BaseResponse<>(diaryProvider.retrieveIsDiaryInMonth(userId, yearAndMonth));
         } catch (BaseException e) {
-            log.warn(e.getMessage());
+            writeExceptionWithAuthorizedRequest(e, request);
             return new BaseResponse<>(e.getStatus());
         }
     }

--- a/src/main/java/com/todoary/ms/src/diary/dto/PostDiaryReq.java
+++ b/src/main/java/com/todoary/ms/src/diary/dto/PostDiaryReq.java
@@ -3,10 +3,12 @@ package com.todoary.ms.src.diary.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class PostDiaryReq {
 
 

--- a/src/main/java/com/todoary/ms/src/s3/AwsS3Service.java
+++ b/src/main/java/com/todoary/ms/src/s3/AwsS3Service.java
@@ -3,7 +3,6 @@ package com.todoary.ms.src.s3;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.todoary.ms.util.BaseException;
 import com.todoary.ms.util.BaseResponseStatus;
@@ -19,7 +18,8 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
 
-import static com.todoary.ms.util.BaseResponseStatus.*;
+import static com.todoary.ms.util.BaseResponseStatus.AWS_ACCESS_DENIED;
+import static com.todoary.ms.util.BaseResponseStatus.AWS_FILE_NOT_FOUND;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -31,11 +31,15 @@ public class AwsS3Service {
     @Value("${cloud.aws.s3.bucket}")
     public String bucket;  // S3 버킷 이름
 
-    public String upload(MultipartFile multipartFile, String dirName) throws IOException {
-        File uploadFile = convert(multipartFile)  // 파일 변환할 수 없으면 에러
-                .orElseThrow(() -> new IllegalArgumentException("error: MultipartFile -> File convert fail"));
-
-        return upload(uploadFile, dirName);
+    public String upload(MultipartFile multipartFile, String dirName) throws BaseException {
+        try {
+            File uploadFile = null;
+            uploadFile = convert(multipartFile)  // 파일 변환할 수 없으면 에러
+                    .orElseThrow(() -> new IllegalArgumentException("error: MultipartFile -> File convert fail"));
+            return upload(uploadFile, dirName);
+        } catch (IOException e) {
+            throw new BaseException(BaseResponseStatus.AWS_FILE_CONVERT_FAIL);
+        }
     }
 
     // S3로 파일 업로드하기

--- a/src/main/java/com/todoary/ms/src/todo/TodoController.java
+++ b/src/main/java/com/todoary/ms/src/todo/TodoController.java
@@ -1,18 +1,19 @@
 package com.todoary.ms.src.todo;
 
 import com.todoary.ms.src.todo.dto.*;
-import com.todoary.ms.src.todo.dto.PostTodoReq;
-import com.todoary.ms.src.todo.dto.PostTodoRes;
 import com.todoary.ms.src.user.UserProvider;
 import com.todoary.ms.util.BaseException;
 import com.todoary.ms.util.BaseResponse;
 import com.todoary.ms.util.BaseResponseStatus;
+import com.todoary.ms.util.ErrorLogWriter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
+
+import static com.todoary.ms.util.ErrorLogWriter.writeExceptionWithAuthorizedRequest;
 
 @Slf4j
 @RestController
@@ -50,10 +51,11 @@ public class TodoController {
             Long todoId = todoService.createTodo(userId, postTodoReq);
             return new BaseResponse<>(new PostTodoRes(todoId));
         } catch (BaseException e) {
-            log.warn(e.getMessage());
+            ErrorLogWriter.writeExceptionWithAuthorizedRequest(e, request, postTodoReq.toString());
             return new BaseResponse<>(e.getStatus());
         }
     }
+
 
     /**
      * 3.2 투두 수정 api
@@ -72,7 +74,7 @@ public class TodoController {
             todoService.modifyTodo(userId, todoId, postTodoReq);
             return new BaseResponse<>(BaseResponseStatus.SUCCESS);
         } catch (BaseException e) {
-            log.warn(e.getMessage());
+            ErrorLogWriter.writeExceptionWithAuthorizedRequest(e, request, postTodoReq.toString());
             return new BaseResponse<>(e.getStatus());
         }
     }
@@ -92,7 +94,7 @@ public class TodoController {
             todoService.removeTodo(userId, todoId);
             return new BaseResponse<>(BaseResponseStatus.SUCCESS);
         } catch (BaseException e) {
-            log.warn(e.getMessage());
+            ErrorLogWriter.writeExceptionWithAuthorizedRequest(e, request);
             return new BaseResponse<>(e.getStatus());
         }
     }
@@ -112,7 +114,7 @@ public class TodoController {
             Long userId = getUserIdFromRequest(request);
             return new BaseResponse<>(todoProvider.retrieveTodoListByDate(userId, targetDate));
         } catch (BaseException e) {
-            log.warn(e.getMessage());
+            ErrorLogWriter.writeExceptionWithAuthorizedRequest(e, request);
             return new BaseResponse<>(e.getStatus());
         }
     }
@@ -133,7 +135,7 @@ public class TodoController {
             Long userId = getUserIdFromRequest(request);
             return new BaseResponse<>(todoProvider.retrieveTodoListByCategory(userId, categoryId));
         } catch (BaseException e) {
-            log.warn(e.getMessage());
+            ErrorLogWriter.writeExceptionWithAuthorizedRequest(e, request);
             return new BaseResponse<>(e.getStatus());
         }
     }
@@ -154,7 +156,7 @@ public class TodoController {
             todoService.modifyTodoCheck(userId, patchTodoCheckReq.getTodoId(), patchTodoCheckReq.isChecked());
             return new BaseResponse<>(BaseResponseStatus.SUCCESS);
         } catch (BaseException e) {
-            log.warn(e.getMessage());
+            writeExceptionWithAuthorizedRequest(e, request, patchTodoCheckReq.toString());
             return new BaseResponse<>(e.getStatus());
         }
     }
@@ -175,7 +177,7 @@ public class TodoController {
             todoService.modifyTodoPin(userId, patchTodoPinReq.getTodoId(), patchTodoPinReq.isPinned());
             return new BaseResponse<>(BaseResponseStatus.SUCCESS);
         } catch (BaseException e) {
-            log.warn(e.getMessage());
+            writeExceptionWithAuthorizedRequest(e, request, patchTodoPinReq.toString());
             return new BaseResponse<>(e.getStatus());
         }
     }
@@ -195,7 +197,7 @@ public class TodoController {
             Long userId = getUserIdFromRequest(request);
             return new BaseResponse<>(todoProvider.retrieveDaysHavingTodoInMonth(userId, yearAndMonth));
         } catch (BaseException e) {
-            log.warn(e.getMessage());
+            ErrorLogWriter.writeExceptionWithAuthorizedRequest(e, request);
             return new BaseResponse<>(e.getStatus());
         }
     }

--- a/src/main/java/com/todoary/ms/src/todo/dto/PatchTodoCheckReq.java
+++ b/src/main/java/com/todoary/ms/src/todo/dto/PatchTodoCheckReq.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class PatchTodoCheckReq {
     private Long todoId;
     @JsonProperty("isChecked")

--- a/src/main/java/com/todoary/ms/src/todo/dto/PatchTodoPinReq.java
+++ b/src/main/java/com/todoary/ms/src/todo/dto/PatchTodoPinReq.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class PatchTodoPinReq {
     private Long todoId;
     @JsonProperty("isPinned")

--- a/src/main/java/com/todoary/ms/src/todo/dto/PostTodoReq.java
+++ b/src/main/java/com/todoary/ms/src/todo/dto/PostTodoReq.java
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
+import lombok.ToString;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class PostTodoReq {
     private String title;
     private String targetDate;

--- a/src/main/java/com/todoary/ms/src/user/dto/PatchAlarmReq.java
+++ b/src/main/java/com/todoary/ms/src/user/dto/PatchAlarmReq.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class PatchAlarmReq {
 
     @JsonProperty("isChecked")

--- a/src/main/java/com/todoary/ms/src/user/dto/PatchTermsReq.java
+++ b/src/main/java/com/todoary/ms/src/user/dto/PatchTermsReq.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class PatchTermsReq {
 
     @JsonProperty("isChecked")

--- a/src/main/java/com/todoary/ms/src/user/dto/PatchUserReq.java
+++ b/src/main/java/com/todoary/ms/src/user/dto/PatchUserReq.java
@@ -3,10 +3,12 @@ package com.todoary.ms.src.user.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class PatchUserReq {
     private String nickname;
     private String introduce;

--- a/src/main/java/com/todoary/ms/util/BaseException.java
+++ b/src/main/java/com/todoary/ms/util/BaseException.java
@@ -9,4 +9,9 @@ import lombok.Setter;
 @AllArgsConstructor
 public class BaseException extends Exception {
     private BaseResponseStatus status;
+
+    @Override
+    public String getMessage() {
+        return status.getMessage();
+    }
 }

--- a/src/main/java/com/todoary/ms/util/BaseResponseStatus.java
+++ b/src/main/java/com/todoary/ms/util/BaseResponseStatus.java
@@ -91,7 +91,8 @@ public enum BaseResponseStatus {
 
     // 5000 : AWS관련 오류
     AWS_ACCESS_DENIED(false,5001 ,"접근 권한이 없습니다."),
-    AWS_FILE_NOT_FOUND(false,5002 ,"파일 키에 해당하는 파일이 존재하지 않습니다.");
+    AWS_FILE_NOT_FOUND(false,5002 ,"파일 키에 해당하는 파일이 존재하지 않습니다."),
+    AWS_FILE_CONVERT_FAIL(false, 5003, "파일 변환에 실패했습니다.");
     // 6000 : 필요시 만들어서 쓰세요
 
 

--- a/src/main/java/com/todoary/ms/util/ErrorLogWriter.java
+++ b/src/main/java/com/todoary/ms/util/ErrorLogWriter.java
@@ -1,0 +1,68 @@
+package com.todoary.ms.util;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+
+@Slf4j
+public class ErrorLogWriter {
+
+    /**
+     * jwt 헤더가 포함된 request 로그를 남길 때 user id 정보를 로그에 같이 남긴다.
+     * 로그에 request 정보와 그 때의 exception 메세지를 남긴다.
+     *
+     * @param exception
+     * @param request
+     */
+    public static void writeExceptionWithAuthorizedRequest(Exception exception, HttpServletRequest request) {
+        log.error("{} - user id: {} | query string: {} | uri: {} {}", exception.getMessage(), request.getAttribute("user_id").toString(),
+                request.getMethod(), parameterMapToString(request.getParameterMap()), request.getRequestURI());
+    }
+
+    /**
+     * jwt 헤더가 포함된 request 로그를 남길 때 user id 정보를 로그에 같이 남긴다.
+     * 로그에 request 정보와 그 때의 exception 메세지, body를 남긴다.
+     *
+     * @param exception
+     * @param request
+     * @param messageBody
+     */
+    public static void writeExceptionWithAuthorizedRequest(Exception exception, HttpServletRequest request, String messageBody) {
+        log.error("{} - user id: {} | uri: {} {} | query string: {} | body: {}", exception.getMessage(), request.getAttribute("user_id").toString(),
+                request.getMethod(), request.getRequestURI(), parameterMapToString(request.getParameterMap()), messageBody);
+    }
+
+    /**
+     * 로그에 request 정보, exception 메세지, body를 남긴다.
+     *
+     * @param exception
+     * @param request
+     */
+    public static void writeExceptionWithRequest(Exception exception, HttpServletRequest request) {
+        log.error("{} - Authorization: {} | uri: {} {} | query string: {}", exception.getMessage(), request.getHeader("Authorization"),
+                request.getMethod(), request.getRequestURI(), parameterMapToString(request.getParameterMap()));
+    }
+
+    public static void writeExceptionWithRequest(Exception exception, HttpServletRequest request, String messageBody) {
+        log.error("{} - Authorization: {} | uri: {} {} | query string: {} | body: {}", exception.getMessage(), request.getHeader("Authorization"),
+                request.getMethod(), request.getRequestURI(), parameterMapToString(request.getParameterMap()), messageBody);
+    }
+
+    /**
+     * 로그에 메세지와 그 때의 exception 메세지를 남긴다
+     *
+     * @param exception
+     * @param message   로그에 남길 메세지
+     */
+    public static void writeExceptionWithMessage(Exception exception, String message) {
+        log.error("{} - {}", exception.getMessage(), message);
+    }
+
+    private static String parameterMapToString(Map<String, String[]> parameters) {
+        return parameters.entrySet().stream()
+                .map(p -> p.getKey() + "=" + String.join(",", p.getValue()))
+                .reduce((p1, p2) -> p1 + "&" + p2)
+                .orElse("");
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <springProperty name="SLACK_WEBHOOK_URI" source="logging.slack.webhook-uri"/>
+    <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
+        <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %msg %n</pattern>
+        </layout>
+        <username>Todoary Server Log</username>
+        <iconEmoji>:face_with_rolling_eyes:</iconEmoji>
+        <colorCoding>true</colorCoding>
+    </appender>
+
+    <!-- Consol appender 설정 -->
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <Pattern>%d %-5level %logger{35} - %msg%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="SLACK"/>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="Console" />
+        <appender-ref ref="ASYNC_SLACK"/>
+    </root>
+</configuration>


### PR DESCRIPTION
- 매번 클라분들이 에러 발생했다고 해주셔야 에러가 발생한 걸 알 수 있고, 에러 로그도 그 때 서버 접속가능한 사람이 확인할 수 있어서 불편함
- 그리고 실제 배포 후엔 유저가 에러 발생했다고 알려주지 않음

그래서 error 레벨 이상의 로그 발생 시에 슬랙 채널(초대해드렸습니다)에 알림이 오도록 추가했습니다.

컨트롤러에서 log.error()만 해도 알림이 가지만, 그 때의 uri나 user id같은 것도 같이 적히는 게 좋을 것 같아서 같이 로그에 적는 함수 `ErrorLogWriter` 클래스에 만들어놨습니다. 구현하면서 로그 찍을 일 있으면 이 클래스에 있는 메소드 이용하거나 여기에 추가로 구현해서 사용해주세요! 그리고 웬만하면 Controller에서 에러 발생시에는 다 로그 남기면 좋을 것 같습니다.
+) **모든 Controller에 로그 찍게 해놨긴 한데 제가 빠뜨린 부분 있으면 추가해주시면 감사합니다**

### 설명
1. Authorized Request 로그 찍기
```java
public static void writeExceptionWithAuthorizedRequest(Exception exception, HttpServletRequest request)
```
    
- Authorized Request, 즉 헤더에 authorization 헤더가 있어서 user id를 읽어올 수 있는 경우엔 해당 id도 같이 찍히도록 했습니다. 

```java
public static void writeExceptionWithAuthorizedRequest(Exception exception, HttpServletRequest request, String messageBody)
```
    
- 이 때 Body값이 있는 요청이라 @RequestBody로 받은 값이 있다면 같이 toString으로 변환해서 세번째 인자에 넣어주면 됩니다.

2. Request 로그 찍기
```java
public static void writeExceptionWithRequest(Exception exception, HttpServletRequest request)
public static void writeBaseExceptionWithRequest(Exception exception, HttpServletRequest request, String messageBody)
```
- 1번과 같이 사용하면 되는데 Authorization 헤더가 없는 경우 (auth 도메인) 사용하면 됩니다.

3. Request 아닌 에러일 때 로그 찍기
```java
public static void writeBaseExceptionWithMessage(Exception exception, String message)
```
- Exception발생했는데 request아닐 때 메모 메세지 남길 수 있도록 했습니다.

### 슬랙 설정
로컬에서도 슬랙에 알림이 가게 테스트해보고 싶다면
```yaml
logging:
  slack:
    webhook-uri: 
  config: classpath:logback-spring.xml
```
webhook-uri에는 슬랙 설명에 적어놓은 url 추가하면 됩니다.
