### PR TITLE
[Fix] Count grapheme include emoji

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 
 	// Slack
 	implementation 'com.github.maricn:logback-slack-appender:1.4.0'
+
+	// emoji 포함 길이
+	implementation group: 'com.ibm.icu', name: 'icu4j', version: '63.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/todoary/ms/src/category/CategoryController.java
+++ b/src/main/java/com/todoary/ms/src/category/CategoryController.java
@@ -39,7 +39,7 @@ public class CategoryController {
 
     @PostMapping("")
     public BaseResponse<PostCategoryRes> postCategory(HttpServletRequest request, @RequestBody PostCategoryReq postCategoryReq) {
-        if (postCategoryReq.getTitle().length() > FormatInfo.CATEGORY_TITLE_LENGTH.getLength())
+        if (FormatInfo.getGraphemeLength(postCategoryReq.getTitle()) > FormatInfo.CATEGORY_TITLE_LENGTH.getLength())
             return new BaseResponse<>(BaseResponseStatus.DATA_TOO_LONG);
         try {
             Long user_id = Long.parseLong(request.getAttribute("user_id").toString());
@@ -63,7 +63,7 @@ public class CategoryController {
     public BaseResponse<BaseResponseStatus> patchCategory(HttpServletRequest request,
                                                           @PathVariable("categoryId") Long categoryId,
                                                           @RequestBody PostCategoryReq postCategoryReq) {
-        if (postCategoryReq.getTitle().length() > FormatInfo.CATEGORY_TITLE_LENGTH.getLength())
+        if (FormatInfo.getGraphemeLength(postCategoryReq.getTitle()) > FormatInfo.CATEGORY_TITLE_LENGTH.getLength())
             return new BaseResponse<>(BaseResponseStatus.DATA_TOO_LONG);
         try {
             Long user_id = Long.parseLong(request.getAttribute("user_id").toString());

--- a/src/main/java/com/todoary/ms/src/diary/DiaryController.java
+++ b/src/main/java/com/todoary/ms/src/diary/DiaryController.java
@@ -44,7 +44,7 @@ public class DiaryController {
      */
     @PostMapping("/{createdDate}")
     public BaseResponse<BaseResponseStatus> postDiary(HttpServletRequest request, @RequestBody PostDiaryReq postDiaryReq, @PathVariable("createdDate") String createdDate) {
-        if (postDiaryReq.getTitle().length() > FormatInfo.DIARY_TITLE_LENGTH.getLength())
+        if (FormatInfo.getGraphemeLength(postDiaryReq.getTitle()) > FormatInfo.DIARY_TITLE_LENGTH.getLength())
             return new BaseResponse<>(BaseResponseStatus.DATA_TOO_LONG);
         try {
             Long userId = getUserIdFromRequest(request);

--- a/src/main/java/com/todoary/ms/src/todo/TodoController.java
+++ b/src/main/java/com/todoary/ms/src/todo/TodoController.java
@@ -43,7 +43,7 @@ public class TodoController {
      */
     @PostMapping("")
     public BaseResponse<PostTodoRes> postTodo(HttpServletRequest request, @RequestBody PostTodoReq postTodoReq) {
-        if (postTodoReq.getTitle().length() > FormatInfo.TODO_TITLE_LENGTH.getLength())
+        if (FormatInfo.getGraphemeLength(postTodoReq.getTitle()) > FormatInfo.TODO_TITLE_LENGTH.getLength())
             return new BaseResponse<>(BaseResponseStatus.DATA_TOO_LONG);
         try {
             Long userId = getUserIdFromRequest(request);
@@ -68,7 +68,7 @@ public class TodoController {
     public BaseResponse<BaseResponseStatus> patchTodo(HttpServletRequest request,
                                                       @PathVariable("todoId") Long todoId,
                                                       @RequestBody PostTodoReq postTodoReq) {
-        if (postTodoReq.getTitle().length() > FormatInfo.TODO_TITLE_LENGTH.getLength())
+        if (FormatInfo.getGraphemeLength(postTodoReq.getTitle()) > FormatInfo.TODO_TITLE_LENGTH.getLength())
             return new BaseResponse<>(BaseResponseStatus.DATA_TOO_LONG);
         try {
             Long userId = getUserIdFromRequest(request);

--- a/src/main/java/com/todoary/ms/util/FormatInfo.java
+++ b/src/main/java/com/todoary/ms/util/FormatInfo.java
@@ -1,5 +1,6 @@
 package com.todoary.ms.util;
 
+import com.ibm.icu.text.BreakIterator;
 import lombok.Getter;
 
 @Getter
@@ -12,5 +13,24 @@ public enum FormatInfo {
 
     private FormatInfo(int length) {
         this.length = length;
+    }
+
+    /**
+     * 사용자가 인식하는 글자 단위로 개수 세기
+     * 참고
+     * - 글자 수를 세는 7가지 방법: https://engineering.linecorp.com/ko/blog/the-7-ways-of-counting-characters/
+     * - 자바 기본 라이브러리 사용 시 몇몇 이모티콘을 제대로 세지 못하는 문제: https://stackoverflow.com/questions/40878804/how-to-count-grapheme-clusters-or-perceived-emoji-characters-in-java
+     *
+     * @param value
+     * @return count
+     */
+    public static int getGraphemeLength(String value) {
+        BreakIterator it = BreakIterator.getCharacterInstance();
+        it.setText(value);
+        int count = 0;
+        while (it.next() != BreakIterator.DONE) {
+            count++;
+        }
+        return count;
     }
 }


### PR DESCRIPTION
- [X] 이모지 포함 글자 수 세기
------------------

mysql에서 이모지 하나를 길이 1이 아닌 byte 수에 따라서 여러 길이로 인식한다.
```sql
SELECT CHAR_LENGTH('🙇🏻'); -- 2
SELECT CHAR_LENGTH('👩‍🚀'); -- 3
SELECT CHAR_LENGTH('👨‍👩‍👧‍👧'); -- 7
```
따라서 서버에서 하나씩 개수를 세서 원하는 개수를 넘지 않는 지 체크하도록 했다.

### 참고
- [글자 수를 세는 7가지 방법](https://engineering.linecorp.com/ko/blog/the-7-ways-of-counting-characters/): 여기서 찾은 대로 grapheme 길이로 체크했다.
- [How to count grapheme clusters or "perceived" emoji characters in Java](https://stackoverflow.com/questions/40878804/how-to-count-grapheme-clusters-or-perceived-emoji-characters-in-java): 여기 나온 대로 java에서 기본제공되는 BreakIterator 사용 시에 더 긴 이모티콘의 길이를 제대로 세지 못해서 ibm에서 제공하고 있는 구현체를 사용했다.

