### PR TITLE
fix: h2 콘솔 웹으로 접근할 수 있다

### DIFF
--- a/src/main/java/com/todoary/ms/src/config/SecurityConfig.java
+++ b/src/main/java/com/todoary/ms/src/config/SecurityConfig.java
@@ -73,6 +73,9 @@ public class SecurityConfig {
                 .antMatchers("/swagger-resources/**").permitAll()
                 .antMatchers("/v2/api-docs").permitAll()
                 .antMatchers("/health").permitAll()
+                // h2 console
+                .antMatchers("/h2-console/**").permitAll()
+                .antMatchers("/favicon.ico").permitAll()
                 .and()
                 .authorizeRequests()
                 .anyRequest().authenticated()
@@ -84,7 +87,7 @@ public class SecurityConfig {
                 .userInfoEndpoint().userService(principalOAuth2UserService)
                 .and()
                 .successHandler(new OAuth2SuccessHandler(jwtTokenProvider, authService));
-
+        http.headers().frameOptions().sameOrigin();
         return http.build();
     }
 }


### PR DESCRIPTION
- [X] 테스트 시 스프링에서 띄워주는 h2 를 이용했는데 웹콘솔이 접근되지 않아 Security 수정