### PR TITLE
Closes #156 feat: Category 도메인 JDBC에서 JPA로 변경, 테스트한다

### DIFF
--- a/src/main/java/com/todoary/ms/TodoaryApplication.java
+++ b/src/main/java/com/todoary/ms/TodoaryApplication.java
@@ -4,6 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -11,6 +12,7 @@ import javax.annotation.PostConstruct;
 import java.util.TimeZone;
 
 @EnableScheduling
+@EnableJpaAuditing
 @SpringBootApplication
 public class TodoaryApplication {
 

--- a/src/main/java/com/todoary/ms/src/category/CategoryController.java
+++ b/src/main/java/com/todoary/ms/src/category/CategoryController.java
@@ -20,11 +20,11 @@ import static com.todoary.ms.util.ErrorLogWriter.writeExceptionWithAuthorizedReq
 @RestController
 @RequestMapping("/category")
 public class CategoryController {
-    private final CategoryService categoryService;
+    private final JdbcCategoryService categoryService;
     private final CategoryProvider categoryProvider;
 
     @Autowired
-    public CategoryController(CategoryService categoryService, CategoryProvider categoryProvider) {
+    public CategoryController(JdbcCategoryService categoryService, CategoryProvider categoryProvider) {
         this.categoryService = categoryService;
         this.categoryProvider = categoryProvider;
     }

--- a/src/main/java/com/todoary/ms/src/category/JdbcCategoryService.java
+++ b/src/main/java/com/todoary/ms/src/category/JdbcCategoryService.java
@@ -1,7 +1,6 @@
 package com.todoary.ms.src.category;
 
 import com.todoary.ms.src.category.dto.PostCategoryReq;
-import com.todoary.ms.src.todo.dto.PostTodoReq;
 import com.todoary.ms.src.user.UserProvider;
 import com.todoary.ms.util.BaseException;
 import com.todoary.ms.util.BaseResponseStatus;
@@ -15,14 +14,14 @@ import static com.todoary.ms.util.BaseResponseStatus.*;
 
 @Slf4j
 @Service
-public class CategoryService {
+public class JdbcCategoryService {
 
     private final CategoryProvider categoryProvider;
     private final CategoryDao categoryDao;
     private final UserProvider userProvider;
 
     @Autowired
-    public CategoryService(CategoryProvider categoryProvider, CategoryDao categoryDao, UserProvider userProvider) {
+    public JdbcCategoryService(CategoryProvider categoryProvider, CategoryDao categoryDao, UserProvider userProvider) {
         this.categoryProvider = categoryProvider;
         this.categoryDao = categoryDao;
         this.userProvider = userProvider;

--- a/src/main/java/com/todoary/ms/src/domain/BaseTimeEntity.java
+++ b/src/main/java/com/todoary/ms/src/domain/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package com.todoary.ms.src.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/todoary/ms/src/domain/Category.java
+++ b/src/main/java/com/todoary/ms/src/domain/Category.java
@@ -9,7 +9,7 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Category extends BaseTimeEntity{
+public class Category extends BaseTimeEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "category_id")
     private Long id;
@@ -27,7 +27,12 @@ public class Category extends BaseTimeEntity{
     public Category(String title, Color color, Member member) {
         this.title = title;
         this.color = color;
+        setMember(member);
+    }
+
+    private void setMember(Member member) {
         this.member = member;
+        member.getCategories().add(this);
     }
 
     public void update(String title, Color color) {

--- a/src/main/java/com/todoary/ms/src/domain/Category.java
+++ b/src/main/java/com/todoary/ms/src/domain/Category.java
@@ -1,0 +1,37 @@
+package com.todoary.ms.src.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Category extends BaseTimeEntity{
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_id")
+    private Long id;
+
+    @Column(length = 40)
+    private String title;
+
+    @Embedded
+    private Color color;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    public Category(String title, Color color, Member member) {
+        this.title = title;
+        this.color = color;
+        this.member = member;
+    }
+
+    public void update(String title, Color color) {
+        this.title = title;
+        this.color = color;
+    }
+}

--- a/src/main/java/com/todoary/ms/src/domain/CategoryUpdateRequest.java
+++ b/src/main/java/com/todoary/ms/src/domain/CategoryUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.todoary.ms.src.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CategoryUpdateRequest {
+    private String title;
+    private Integer color;
+}

--- a/src/main/java/com/todoary/ms/src/domain/Color.java
+++ b/src/main/java/com/todoary/ms/src/domain/Color.java
@@ -1,29 +1,15 @@
 package com.todoary.ms.src.domain;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
+@EqualsAndHashCode(of = {"code"})
 @Embeddable
 public class Color {
     @Column(name = "color")
     private Integer code;
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj instanceof Color)
-            return this.getCode().equals(((Color) obj).getCode());
-        return false;
-    }
-
-    @Override
-    public int hashCode() {
-        return this.getCode().hashCode();
-    }
 }

--- a/src/main/java/com/todoary/ms/src/domain/Color.java
+++ b/src/main/java/com/todoary/ms/src/domain/Color.java
@@ -1,0 +1,29 @@
+package com.todoary.ms.src.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
+@Embeddable
+public class Color {
+    @Column(name = "color")
+    private Integer code;
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof Color)
+            return this.getCode().equals(((Color) obj).getCode());
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.getCode().hashCode();
+    }
+}

--- a/src/main/java/com/todoary/ms/src/domain/Member.java
+++ b/src/main/java/com/todoary/ms/src/domain/Member.java
@@ -1,9 +1,10 @@
 package com.todoary.ms.src.domain;
 
-import com.todoary.ms.src.domain.token.FcmToken;
-import com.todoary.ms.src.domain.token.RefreshToken;
 import com.todoary.ms.src.domain.alarm.RemindAlarm;
 import com.todoary.ms.src.domain.alarm.ToDoAlarm;
+import com.todoary.ms.src.domain.token.FcmToken;
+import com.todoary.ms.src.domain.token.RefreshToken;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -13,7 +14,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-@NoArgsConstructor
+@Getter @NoArgsConstructor
 @Entity
 public class Member {
     @Id
@@ -51,7 +52,7 @@ public class Member {
     private List<ToDo> toDos = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Category> categories;
+    private List<Category> categories = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
     private List<Diary> diaries = new ArrayList<>();
@@ -73,7 +74,7 @@ public class Member {
     private LocalDateTime updatedAt;
 
     /*---Constructor---*/
-    private Member(String name, String nickname, String email, String password) {
+    public Member(String name, String nickname, String email, String password) {
         this.name = name;
         this.nickname = nickname;
         this.email = email;

--- a/src/main/java/com/todoary/ms/src/domain/Member.java
+++ b/src/main/java/com/todoary/ms/src/domain/Member.java
@@ -47,8 +47,11 @@ public class Member {
     @OneToOne(mappedBy = "member", fetch = FetchType.LAZY)
     private FcmToken fcmToken;
 
-    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ToDo> toDos = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Category> categories;
 
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
     private List<Diary> diaries = new ArrayList<>();

--- a/src/main/java/com/todoary/ms/src/exception/common/ExceptionController.java
+++ b/src/main/java/com/todoary/ms/src/exception/common/ExceptionController.java
@@ -1,0 +1,18 @@
+package com.todoary.ms.src.exception.common;
+
+import com.todoary.ms.util.BaseResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+// 예외가 발생했을 때 json 형태로 반환할 때 사용하는 어노테이션
+@RestControllerAdvice
+@Slf4j
+public class ExceptionController {
+    @ExceptionHandler(TodoaryException.class)
+    public ResponseEntity<BaseResponse> handleTodoaryException(final TodoaryException exception) {
+        return ResponseEntity.ok()
+                .body(new BaseResponse<>(exception.getStatus()));
+    }
+}

--- a/src/main/java/com/todoary/ms/src/exception/common/TodoaryException.java
+++ b/src/main/java/com/todoary/ms/src/exception/common/TodoaryException.java
@@ -1,10 +1,14 @@
 package com.todoary.ms.src.exception.common;
 
 import com.todoary.ms.util.BaseResponseStatus;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@AllArgsConstructor @Getter
+@Getter
 public class TodoaryException extends RuntimeException{
     private BaseResponseStatus status;
+
+    public TodoaryException(BaseResponseStatus status) {
+        super(status.getMessage());
+        this.status = status;
+    }
 }

--- a/src/main/java/com/todoary/ms/src/exception/common/TodoaryException.java
+++ b/src/main/java/com/todoary/ms/src/exception/common/TodoaryException.java
@@ -1,0 +1,10 @@
+package com.todoary.ms.src.exception.common;
+
+import com.todoary.ms.util.BaseResponseStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor @Getter
+public class TodoaryException extends RuntimeException{
+    private BaseResponseStatus status;
+}

--- a/src/main/java/com/todoary/ms/src/repository/CategoryRepository.java
+++ b/src/main/java/com/todoary/ms/src/repository/CategoryRepository.java
@@ -1,0 +1,28 @@
+package com.todoary.ms.src.repository;
+
+import com.todoary.ms.src.domain.Category;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.Optional;
+
+@Repository
+public class CategoryRepository {
+    @PersistenceContext
+    private EntityManager em;
+
+    public Category save(Category category) {
+        em.persist(category);
+        return category;
+    }
+
+    public Optional<Category> findById(Long id) {
+        return Optional.ofNullable(em.find(Category.class, id));
+    }
+
+    public void delete(Category category) {
+        em.remove(category);
+    }
+
+}

--- a/src/main/java/com/todoary/ms/src/repository/CategoryRepository.java
+++ b/src/main/java/com/todoary/ms/src/repository/CategoryRepository.java
@@ -1,6 +1,7 @@
 package com.todoary.ms.src.repository;
 
 import com.todoary.ms.src.domain.Category;
+import com.todoary.ms.src.domain.Member;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
@@ -23,6 +24,14 @@ public class CategoryRepository {
 
     public void delete(Category category) {
         em.remove(category);
+    }
+
+    public Optional<Category> findByMembersTitle(Member member, String title) {
+        return em.createQuery("select c from Category c where c.member = :member and c.title = :title", Category.class)
+                .setParameter("member", member)
+                .setParameter("title", title)
+                .getResultStream()
+                .findFirst();
     }
 
 }

--- a/src/main/java/com/todoary/ms/src/repository/MemberRepository.java
+++ b/src/main/java/com/todoary/ms/src/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.todoary.ms.src.repository;
+
+import com.todoary.ms.src.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/todoary/ms/src/service/JpaCategoryService.java
+++ b/src/main/java/com/todoary/ms/src/service/JpaCategoryService.java
@@ -1,0 +1,88 @@
+package com.todoary.ms.src.service;
+
+import com.todoary.ms.src.domain.Category;
+import com.todoary.ms.src.domain.CategoryUpdateRequest;
+import com.todoary.ms.src.domain.Color;
+import com.todoary.ms.src.domain.Member;
+import com.todoary.ms.src.exception.common.TodoaryException;
+import com.todoary.ms.src.repository.CategoryRepository;
+import com.todoary.ms.src.repository.MemberRepository;
+import com.todoary.ms.src.web.dto.CategoryResponse;
+import com.todoary.ms.src.web.dto.CategorySaveRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.todoary.ms.util.BaseResponseStatus.*;
+
+@Service
+public class JpaCategoryService {
+
+    private final CategoryRepository categoryRepository;
+    private final MemberRepository memberRepository;
+
+
+    @Autowired
+    public JpaCategoryService(CategoryRepository categoryRepository, MemberRepository memberRepository) {
+        this.categoryRepository = categoryRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public Long saveCategory(Long memberId, CategorySaveRequest request) {
+        Member member = getMemberById(memberId);
+        categoryRepository.findByMembersTitle(member, request.getTitle())
+                .ifPresent((c) -> {
+                    throw new TodoaryException(DUPLICATE_CATEGORY);
+                });
+        return categoryRepository.save(request.toEntity(member)).getId();
+    }
+
+    @Transactional
+    public void updateCategory(Long memberId, Long categoryId, CategoryUpdateRequest request) {
+        Member member = getMemberById(memberId);
+        Category category = getMembersCategoryById(member, categoryId);
+        categoryRepository.findByMembersTitle(member, request.getTitle())
+                .ifPresent((c) -> {
+                    if (!c.getId().equals(categoryId))
+                        throw new TodoaryException(DUPLICATE_CATEGORY);
+                });
+        Color color = new Color(request.getColor());
+        if (category.getTitle().equals(request.getTitle()) && category.getColor().equals(color))
+            return;
+        category.update(request.getTitle(), color);
+    }
+
+    @Transactional
+    public void deleteCategory(Long memberId, Long categoryId) {
+        Member member = getMemberById(memberId);
+        Category category = getMembersCategoryById(member, categoryId);
+        categoryRepository.delete(category);
+    }
+
+    @Transactional(readOnly = false)
+    public List<CategoryResponse> findCategories(Long memberId) {
+        Member member = getMemberById(memberId);
+        return member.getCategories()
+                .stream().map(c -> new CategoryResponse(
+                        c.getId(), c.getTitle(), c.getColor().getCode())
+                ).collect(Collectors.toList());
+    }
+
+    private Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new TodoaryException(USERS_EMPTY_USER_ID));
+    }
+
+    private Category getMembersCategoryById(Member member, Long categoryId) {
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new TodoaryException(USERS_CATEGORY_NOT_EXISTS));
+        if (!category.getMember().equals(member))
+            throw new TodoaryException(USERS_CATEGORY_NOT_EXISTS);
+        return category;
+    }
+
+}

--- a/src/main/java/com/todoary/ms/src/web/dto/CategoryResponse.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/CategoryResponse.java
@@ -1,0 +1,14 @@
+package com.todoary.ms.src.web.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CategoryResponse {
+    private Long id;
+    private String title;
+    private Integer color;
+}

--- a/src/main/java/com/todoary/ms/src/web/dto/CategorySaveRequest.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/CategorySaveRequest.java
@@ -1,0 +1,24 @@
+package com.todoary.ms.src.web.dto;
+
+import com.todoary.ms.src.domain.Category;
+import com.todoary.ms.src.domain.Color;
+import com.todoary.ms.src.domain.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CategorySaveRequest {
+    private String title;
+    private Integer color;
+
+    public CategorySaveRequest(String title, Integer color) {
+        this.title = title;
+        this.color = color;
+    }
+
+    public Category toEntity(Member member) {
+        return new Category(title, new Color(color), member);
+    }
+}
+

--- a/src/test/java/com/todoary/ms/src/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/todoary/ms/src/repository/CategoryRepositoryTest.java
@@ -1,0 +1,73 @@
+package com.todoary.ms.src.repository;
+
+import com.todoary.ms.src.domain.Category;
+import com.todoary.ms.src.domain.Color;
+import com.todoary.ms.src.domain.Member;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional @SpringBootTest
+class CategoryRepositoryTest {
+    
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Test
+    void Category_저장_조회() {
+        // given
+        Member member = null;
+        String title = "title";
+        Color color = new Color(10);
+        Long categoryId = categoryRepository.save(new Category(title, color, member)).getId();
+        // when
+        Category found = categoryRepository.findById(categoryId).get();
+        // then
+        assertThat(found.getTitle()).isEqualTo(title);
+        assertThat(found.getColor()).isEqualTo(color);
+    }
+
+    @Test
+    void Category_수정() {
+        // given
+        Category category = categoryRepository.save(new Category("title", new Color(10), null));
+        String expectedTitle = "title2";
+        Color expectedColor = new Color(17);
+        category.update(expectedTitle, expectedColor);
+        // when
+        Category found = categoryRepository.findById(category.getId()).get();
+        // then
+        assertThat(found.getTitle()).isEqualTo(expectedTitle);
+        assertThat(found.getColor()).isEqualTo(expectedColor);
+    }
+
+    @Test
+    void Category_삭제() {
+        // given
+        Category category = categoryRepository.save(new Category("title", new Color(10), null));
+        Long id = category.getId();
+        // when
+        categoryRepository.delete(category);
+        // then
+        assertThat(categoryRepository.findById(id)).isEmpty();
+    }
+
+    @Test
+    void BaseTimeEntity로_생성_수정_시간_저장() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        Category category = categoryRepository.save(new Category("title", new Color(10), null));
+        // when
+        Category found = categoryRepository.findById(category.getId()).get();
+        // then
+        System.out.println("found.getCreatedAt() = " + found.getCreatedAt());
+        System.out.println("found.getModifiedAt() = " + found.getModifiedAt());
+        assertThat(found.getCreatedAt()).isAfter(now);
+        assertThat(found.getModifiedAt()).isAfter(now);
+    }
+}

--- a/src/test/java/com/todoary/ms/src/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/todoary/ms/src/repository/CategoryRepositoryTest.java
@@ -8,20 +8,25 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityManager;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Transactional @SpringBootTest
+@Transactional
+@SpringBootTest
 class CategoryRepositoryTest {
-    
+
+    @Autowired
+    EntityManager em;
+
     @Autowired
     CategoryRepository categoryRepository;
 
     @Test
     void Category_저장_조회() {
         // given
-        Member member = null;
+        Member member = createMember();
         String title = "title";
         Color color = new Color(10);
         Long categoryId = categoryRepository.save(new Category(title, color, member)).getId();
@@ -35,7 +40,8 @@ class CategoryRepositoryTest {
     @Test
     void Category_수정() {
         // given
-        Category category = categoryRepository.save(new Category("title", new Color(10), null));
+        Member member = createMember();
+        Category category = categoryRepository.save(new Category("title", new Color(10), member));
         String expectedTitle = "title2";
         Color expectedColor = new Color(17);
         category.update(expectedTitle, expectedColor);
@@ -49,7 +55,8 @@ class CategoryRepositoryTest {
     @Test
     void Category_삭제() {
         // given
-        Category category = categoryRepository.save(new Category("title", new Color(10), null));
+        Member member = createMember();
+        Category category = categoryRepository.save(new Category("title", new Color(10), member));
         Long id = category.getId();
         // when
         categoryRepository.delete(category);
@@ -60,8 +67,9 @@ class CategoryRepositoryTest {
     @Test
     void BaseTimeEntity로_생성_수정_시간_저장() {
         // given
+        Member member = createMember();
         LocalDateTime now = LocalDateTime.now();
-        Category category = categoryRepository.save(new Category("title", new Color(10), null));
+        Category category = categoryRepository.save(new Category("title", new Color(10), member));
         // when
         Category found = categoryRepository.findById(category.getId()).get();
         // then
@@ -69,5 +77,11 @@ class CategoryRepositoryTest {
         System.out.println("found.getModifiedAt() = " + found.getModifiedAt());
         assertThat(found.getCreatedAt()).isAfter(now);
         assertThat(found.getModifiedAt()).isAfter(now);
+    }
+
+    Member createMember() {
+        Member member = new Member();
+        em.persist(member);
+        return member;
     }
 }

--- a/src/test/java/com/todoary/ms/src/service/CategoryServiceTest.java
+++ b/src/test/java/com/todoary/ms/src/service/CategoryServiceTest.java
@@ -1,0 +1,151 @@
+package com.todoary.ms.src.service;
+
+import com.todoary.ms.src.domain.Category;
+import com.todoary.ms.src.domain.CategoryUpdateRequest;
+import com.todoary.ms.src.domain.Member;
+import com.todoary.ms.src.exception.common.TodoaryException;
+import com.todoary.ms.src.repository.CategoryRepository;
+import com.todoary.ms.src.repository.MemberRepository;
+import com.todoary.ms.src.web.dto.CategoryResponse;
+import com.todoary.ms.src.web.dto.CategorySaveRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.Optional;
+
+import static com.todoary.ms.util.BaseResponseStatus.DUPLICATE_CATEGORY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@Transactional
+@SpringBootTest
+class CategoryServiceTest {
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    JpaCategoryService categoryService;
+
+    @MockBean
+    MemberRepository memberRepository;
+
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Test
+    void Category_생성한다() {
+        // given
+        Member member = createMember();
+        String expectedTitle = "title";
+        Integer expectedColor = 10;
+        // when
+        Long categoryId = categoryService.saveCategory(member.getId(), new CategorySaveRequest(expectedTitle, expectedColor));
+        // then
+        Category found = categoryRepository.findById(categoryId).get();
+        assertThat(found.getTitle()).isEqualTo(expectedTitle);
+        assertThat(found.getColor().getCode()).isEqualTo(expectedColor);
+    }
+
+    @Test
+    void 똑같은_title로_생성_불가() {
+        // given
+        Member member = createMember();
+        String title = "title";
+        Integer color = 10;
+        categoryService.saveCategory(member.getId(), new CategorySaveRequest(title, color));
+
+        // 아래 코드는 junit의 assertThrows를 이용하면 아래와 같다.
+        // TodoaryException exception = Assertions.assertThrows(TodoaryException.class, () -> {
+        // categoryService.saveCategory(member.getId(), new CategorySaveRequest(title, 20));
+        // });
+
+        // then
+        assertThatThrownBy(() -> {
+            // when
+            categoryService.saveCategory(member.getId(), new CategorySaveRequest(title, 20));
+        })
+                .isInstanceOf(TodoaryException.class)
+                .matches(e -> ((TodoaryException) e).getStatus().equals(DUPLICATE_CATEGORY));
+    }
+
+    @Test
+    void Category_수정한다() {
+        // given
+        Member member = createMember();
+        Long categoryId = categoryService.saveCategory(member.getId(), new CategorySaveRequest("title", 10));
+        String expectedTitle = "title2";
+        Integer expectedColor = 17;
+        // when
+        categoryService.updateCategory(member.getId(), categoryId, new CategoryUpdateRequest(expectedTitle, expectedColor));
+        Category found = categoryRepository.findById(categoryId).get();
+        // then
+        assertThat(found.getTitle()).isEqualTo(expectedTitle);
+        assertThat(found.getColor().getCode()).isEqualTo(expectedColor);
+    }
+
+    @Test
+    void 다른_카테고리와_똑같은_title로_수정_불가() {
+        // given
+        Member member = createMember();
+        String title = "title";
+        Integer color = 10;
+        Long categoryId = categoryService.saveCategory(member.getId(), new CategorySaveRequest(title, color));
+        Long otherCategoryId = categoryService.saveCategory(member.getId(), new CategorySaveRequest("title12341235", 30));
+        // when
+        // 같은 카테고리를 똑같은 이름으로 수정하는 것은 괜찮음
+        categoryService.updateCategory(member.getId(), categoryId, new CategoryUpdateRequest(title, 15));
+        // then
+        assertThatThrownBy(() -> {
+            // 다른 카테고리와 똑같은 이름으로 수정할 수는 없다.
+            categoryService.updateCategory(member.getId(), otherCategoryId, new CategoryUpdateRequest(title, 15));
+        })
+                .isInstanceOf(TodoaryException.class)
+                .matches(e -> ((TodoaryException) e).getStatus().equals(DUPLICATE_CATEGORY));
+    }
+
+    @Test
+    void Category_삭제한다() {
+        // given
+        Member member = createMember();
+        Long categoryId = categoryService.saveCategory(member.getId(), new CategorySaveRequest("title", 10));
+        // when
+        categoryService.deleteCategory(member.getId(), categoryId);
+        // then
+        assertThat(categoryRepository.findById(categoryId)).isEmpty();
+    }
+
+    @Test
+    void 멤버의_모든_카테고리_조회() {
+        // given
+        Member member = createMember();
+        List<CategorySaveRequest> requests = List.of(
+                new CategorySaveRequest("title1", 10),
+                new CategorySaveRequest("title2", 15),
+                new CategorySaveRequest("title3", 10)
+        );
+        for (CategorySaveRequest request : requests)
+            categoryService.saveCategory(member.getId(), request);
+        // when
+        List<CategoryResponse> categories = categoryService.findCategories(member.getId());
+        // then
+        assertThat(categories.size()).isEqualTo(requests.size());
+        for (int i = 0; i < categories.size(); i++) {
+            assertThat(categories.get(i).getTitle()).isEqualTo(requests.get(i).getTitle());
+            assertThat(categories.get(i).getColor()).isEqualTo(requests.get(i).getColor());
+        }
+    }
+
+    Member createMember() {
+        Member member = new Member();
+        em.persist(member);
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.ofNullable(member));
+        return member;
+    }
+}


### PR DESCRIPTION
- [X] Category 엔티티 생성
- [X] CategoryRepository
- [X] CategoryService (기존에 있던 CategoryService는 JdbcCategoryService로 변경, 새로운 서비스는 JpaCategoryService로 네이밍함)