### PR TITLE
fix: Category에서 Member 연관관계 편의 메서드에서 이전 관계 제거한다

### DIFF
--- a/src/main/java/com/todoary/ms/src/domain/Category.java
+++ b/src/main/java/com/todoary/ms/src/domain/Category.java
@@ -31,6 +31,11 @@ public class Category extends BaseTimeEntity {
     }
 
     private void setMember(Member member) {
+        // 카테고리의 멤버가 바뀌는 일은 없지만...
+        // 실수로 한 번 더 호출됐을 때 중복으로 더해지는 경우를 방지
+        if (this.member != null) {
+            this.member.getCategories().remove(this);
+        }
         this.member = member;
         member.getCategories().add(this);
     }


### PR DESCRIPTION
## What is this PR? 🔍
- 연관관계 설정 시에 이미 설정되어 있는 경우 제거하는 부분을 빼먹음

## Changes 📝
- 연관관계 설정 시에 이미 설정되어 있는 경우 제거

## To Reviewers 📢
Member와 Category가 일대다 관계이므로 Category를 연관관계 주인으로 설정했습니다.
Category 생성 시에 무조건 setMember함수 통해서 member 등록하며,
등록 시에 member의 categories에도 add해서 연관관계 편입하는 방식으로 했습니다.

