### PR TITLE
fix: Category삭제 시 부모에서 제거한다

### DIFF
--- a/src/main/java/com/todoary/ms/src/domain/Category.java
+++ b/src/main/java/com/todoary/ms/src/domain/Category.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -23,6 +25,9 @@ public class Category extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ToDo> todos = new ArrayList<>();
 
     public Category(String title, Color color, Member member) {
         this.title = title;
@@ -43,5 +48,9 @@ public class Category extends BaseTimeEntity {
     public void update(String title, Color color) {
         this.title = title;
         this.color = color;
+    }
+
+    public void removeAssociations(){
+        this.member.getCategories().remove(this);
     }
 }

--- a/src/main/java/com/todoary/ms/src/domain/Color.java
+++ b/src/main/java/com/todoary/ms/src/domain/Color.java
@@ -6,8 +6,8 @@ import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
-@EqualsAndHashCode(of = {"code"})
+@AllArgsConstructor @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
 @Embeddable
 public class Color {
     @Column(name = "color")

--- a/src/main/java/com/todoary/ms/src/domain/ToDo.java
+++ b/src/main/java/com/todoary/ms/src/domain/ToDo.java
@@ -20,6 +20,10 @@ public class ToDo {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
     private LocalDate targetDate;
 
     private LocalDateTime targetTime;

--- a/src/main/java/com/todoary/ms/src/service/JpaCategoryService.java
+++ b/src/main/java/com/todoary/ms/src/service/JpaCategoryService.java
@@ -60,6 +60,7 @@ public class JpaCategoryService {
     public void deleteCategory(Long memberId, Long categoryId) {
         Member member = getMemberById(memberId);
         Category category = getMembersCategoryById(member, categoryId);
+        category.removeAssociations();
         categoryRepository.delete(category);
     }
 

--- a/src/test/java/com/todoary/ms/src/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/todoary/ms/src/repository/CategoryRepositoryTest.java
@@ -59,9 +59,11 @@ class CategoryRepositoryTest {
         Category category = categoryRepository.save(new Category("title", new Color(10), member));
         Long id = category.getId();
         // when
+        category.removeAssociations();
         categoryRepository.delete(category);
         // then
         assertThat(categoryRepository.findById(id)).isEmpty();
+        assertThat(member.getCategories()).hasSize(0);
     }
 
     @Test

--- a/src/test/java/com/todoary/ms/src/service/CategoryServiceTest.java
+++ b/src/test/java/com/todoary/ms/src/service/CategoryServiceTest.java
@@ -119,6 +119,7 @@ class CategoryServiceTest {
         categoryService.deleteCategory(member.getId(), categoryId);
         // then
         assertThat(categoryRepository.findById(categoryId)).isEmpty();
+        assertThat(member.getCategories()).hasSize(0);
     }
 
     @Test


### PR DESCRIPTION
## What is this PR? 🔍
- Category remove시 member(부모)에서 제거

## Changes 📝
- Category remove시 member(부모)에서 제거
```java
// Category
public void removeAssociations(){
    this.member.getCategories().remove(this);
}
```

## To Reviewers 📢
### 질문
`orphanRemoval = true`하면 부모가 삭제되면 자식까지 삭제되는 건 알겠는데,
자식이 삭제될 때는 이렇게 부모에서 삭제해야하는 게 맞는 거죠? 

