### PR TITLE
feat: 일반적인 Exception 발생 시에도 클라이언트에 공통된 응답을 보내고, 로그로 남긴다

### DIFF
--- a/src/main/java/com/todoary/ms/src/exception/common/ExceptionController.java
+++ b/src/main/java/com/todoary/ms/src/exception/common/ExceptionController.java
@@ -1,18 +1,30 @@
 package com.todoary.ms.src.exception.common;
 
 import com.todoary.ms.util.BaseResponse;
+import com.todoary.ms.util.BaseResponseStatus;
+import com.todoary.ms.util.ErrorLogWriter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.servlet.http.HttpServletRequest;
 
 // 예외가 발생했을 때 json 형태로 반환할 때 사용하는 어노테이션
 @RestControllerAdvice
 @Slf4j
 public class ExceptionController {
     @ExceptionHandler(TodoaryException.class)
-    public ResponseEntity<BaseResponse> handleTodoaryException(final TodoaryException exception) {
+    private ResponseEntity<BaseResponse> handleTodoaryException(TodoaryException exception, HttpServletRequest httpServletRequest) {
+        ErrorLogWriter.writeExceptionWithRequest(exception, httpServletRequest);
         return ResponseEntity.ok()
                 .body(new BaseResponse<>(exception.getStatus()));
+    }
+
+    @ExceptionHandler({ Exception.class })
+    private ResponseEntity handleServerException(Exception exception, HttpServletRequest httpServletRequest) {
+        ErrorLogWriter.writeExceptionWithRequest(exception, httpServletRequest);
+        return ResponseEntity.ok()
+                .body(new BaseResponse<>(BaseResponseStatus.INTERNAL_SERVER_ERROR));
     }
 }

--- a/src/main/java/com/todoary/ms/util/BaseResponseStatus.java
+++ b/src/main/java/com/todoary/ms/util/BaseResponseStatus.java
@@ -83,6 +83,8 @@ public enum BaseResponseStatus {
     DATABASE_ERROR(false, 4000, "데이터베이스 연결에 실패하였습니다."),
     SERVER_ERROR(false, 4001, "서버와의 연결에 실패하였습니다."),
 
+    INTERNAL_SERVER_ERROR(false, 4004, "서버에서 에러가 발생했습니다"),
+
     //[PATCH] /users/{userIdx}
     MODIFY_FAIL_USERNAME(false, 4014, "유저네임 수정 실패"),
     MODIFY_FAIL_FCMTOKEN(false, 4015, "FCM Token 수정 실패"),


### PR DESCRIPTION
## What is this PR? 🔍
- 클라에게 응답하는 에러 response 개선
- 에러 로그 남김 

## Changes 📝
- 현재 ControllerAdvice에 개발자가 남긴 TodoaryException들만 받아서 response 처리하도록 되어있어서, 예상치 못하게 발생할 수 있는 일반적인 예외들도 받아서 일관되게 response처리하도록 수정했습니다.
- 에러 발생 시에 로그로 남기는 로직이 없어서 ErrorHandler에서 에러를 받고 error 레벨의 로그로 남기도록 했습니다.

