### PR TITLE
Closes #201 feat: 카테고리로 투두 조회 시 페이징 적용한다

### DIFF
--- a/src/main/java/com/todoary/ms/TodoaryApplication.java
+++ b/src/main/java/com/todoary/ms/TodoaryApplication.java
@@ -3,14 +3,12 @@ package com.todoary.ms;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.annotation.PostConstruct;
 import java.util.TimeZone;
 
-@EnableScheduling
 @SpringBootApplication
 public class TodoaryApplication {
 

--- a/src/main/java/com/todoary/ms/src/config/SchedulingConfig.java
+++ b/src/main/java/com/todoary/ms/src/config/SchedulingConfig.java
@@ -1,0 +1,11 @@
+package com.todoary.ms.src.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@Profile({"release"})
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/com/todoary/ms/src/config/SecurityConfig.java
+++ b/src/main/java/com/todoary/ms/src/config/SecurityConfig.java
@@ -76,6 +76,8 @@ public class SecurityConfig {
                 // h2 console
                 .antMatchers("/h2-console/**").permitAll()
                 .antMatchers("/favicon.ico").permitAll()
+                // for test
+                .antMatchers("/jpa/test").permitAll()
                 .and()
                 .authorizeRequests()
                 .anyRequest().authenticated()

--- a/src/main/java/com/todoary/ms/src/config/SwaggerConfig.java
+++ b/src/main/java/com/todoary/ms/src/config/SwaggerConfig.java
@@ -1,13 +1,20 @@
 package com.todoary.ms.src.config;
 
+import com.fasterxml.classmate.TypeResolver;
 import com.todoary.ms.src.config.auth.LoginMember;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.schema.AlternateTypeRules;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.service.ApiKey;
 import springfox.documentation.service.AuthorizationScope;
@@ -28,6 +35,12 @@ public class SwaggerConfig {
 
     @Value("${swagger.host}")
     private String hostUrl;
+    private final TypeResolver typeResolver;
+
+    @Autowired
+    public SwaggerConfig(TypeResolver typeResolver) {
+        this.typeResolver = typeResolver;
+    }
 
     private ApiInfo swaggerInfo() {
         return new ApiInfoBuilder().title("Todoary API")
@@ -45,6 +58,8 @@ public class SwaggerConfig {
                 .apiInfo(swaggerInfo())
                 .securityContexts(List.of(securityContext()))
                 .securitySchemes(List.of(apiKey()))
+                .alternateTypeRules(
+                        AlternateTypeRules.newRule(typeResolver.resolve(Pageable.class), typeResolver.resolve(PageDto.class)))
                 .select()
                 .apis(RequestHandlerSelectors.basePackage("com.todoary.ms.src"))
                 .paths(PathSelectors.any())
@@ -81,5 +96,15 @@ public class SwaggerConfig {
         Set<String> produces = new HashSet<>();
         produces.add("application/json;charset=UTF-8");
         return produces;
+    }
+
+    @Getter
+    @ApiModel
+    private static class PageDto {
+        @ApiModelProperty(value = "페이지 번호(0..N)", example = "0")
+        private int page;
+        @ApiModelProperty(value = "페이지 크기", example = "20")
+        private int size;
+
     }
 }

--- a/src/main/java/com/todoary/ms/src/repository/TodoRepository.java
+++ b/src/main/java/com/todoary/ms/src/repository/TodoRepository.java
@@ -6,6 +6,9 @@ import com.todoary.ms.src.domain.Category;
 import com.todoary.ms.src.domain.Member;
 import com.todoary.ms.src.domain.Todo;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
@@ -54,9 +57,31 @@ public class TodoRepository {
                 .fetch();
     }
 
+    public Slice<Todo> findSliceByCategoryAndSatisfy(Pageable pageable, Category category, Predicate condition) {
+        List<Todo> result = queryFactory.selectFrom(todo)
+                .where(todo.category.eq(category))
+                .where(condition)
+                .offset(pageable.getOffset())
+                // slice는 카운트 쿼리가 없는 대신 게시물이 더 존재하는 지 알아야 하므로 1개 더 가져온다
+                .limit(pageable.getPageSize() + 1)
+                .orderBy(todo.targetDate.asc(), todo.targetTime.asc().nullsLast(), todo.createdAt.asc())
+                .fetch();
+        return checkLastSlice(result, pageable);
+    }
+
+    private Slice<Todo> checkLastSlice(List<Todo> result, Pageable pageable) {
+        boolean hasNext = false;
+        if (result.size() > pageable.getPageSize()) {
+            hasNext = true;
+            // 요청한 만큼만 응답하기 위해 제거
+            result.remove(pageable.getPageSize());
+        }
+        return new SliceImpl<>(result, pageable, hasNext);
+    }
+
     public List<Todo> findBetweenDaysAndMember(LocalDate firstDay, LocalDate lastDay, Member member) {
         return em.createQuery("select t from Todo t where t.member = :member and " +
-                        "t.targetDate between :firstDay and :lastDay order by t.targetDate", Todo.class)
+                                      "t.targetDate between :firstDay and :lastDay order by t.targetDate", Todo.class)
                 .setParameter("member", member)
                 .setParameter("firstDay", firstDay)
                 .setParameter("lastDay", lastDay)

--- a/src/main/java/com/todoary/ms/src/service/todo/JpaTodoService.java
+++ b/src/main/java/com/todoary/ms/src/service/todo/JpaTodoService.java
@@ -7,10 +7,12 @@ import com.todoary.ms.src.exception.common.TodoaryException;
 import com.todoary.ms.src.repository.MemberRepository;
 import com.todoary.ms.src.repository.TodoRepository;
 import com.todoary.ms.src.service.JpaCategoryService;
+import com.todoary.ms.src.web.dto.PageResponse;
 import com.todoary.ms.src.web.dto.TodoAlarmRequest;
 import com.todoary.ms.src.web.dto.TodoRequest;
 import com.todoary.ms.src.web.dto.TodoResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,7 +49,7 @@ public class JpaTodoService {
         todo.update(
                 request.getTitle(),
                 category,
-                request.isAlarmEnabled(),
+                request.getIsAlarmEnabled(),
                 request.getTargetDate(),
                 request.getTargetTime()
         );
@@ -99,6 +101,16 @@ public class JpaTodoService {
         Category category = findCategoryByIdAndMember(categoryId, member);
         return todoRepository.findByCategoryAndSatisfy(category, todoByCategoryCondition.getPredicate())
                 .stream().map(TodoResponse::from).collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<TodoResponse> findTodoPageByCategory(Pageable pageable, Long memberId, Long categoryId) {
+        Member member = findMemberById(memberId);
+        Category category = findCategoryByIdAndMember(categoryId, member);
+        return PageResponse.of(
+                todoRepository
+                        .findSliceByCategoryAndSatisfy(pageable, category, todoByCategoryCondition.getPredicate())
+                        .map(TodoResponse::from));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/todoary/ms/src/web/controller/JpaAuthController.java
+++ b/src/main/java/com/todoary/ms/src/web/controller/JpaAuthController.java
@@ -1,24 +1,17 @@
 package com.todoary.ms.src.web.controller;
 
 import com.todoary.ms.src.auth.model.PrincipalDetails;
-import com.todoary.ms.src.domain.Member;
 import com.todoary.ms.src.domain.token.AccessToken;
 import com.todoary.ms.src.domain.token.RefreshToken;
 import com.todoary.ms.src.service.JpaAuthService;
 import com.todoary.ms.src.service.MemberService;
-import com.todoary.ms.src.user.dto.PatchPasswordReq;
 import com.todoary.ms.src.web.dto.*;
-import com.todoary.ms.util.BaseException;
 import com.todoary.ms.util.BaseResponse;
 import com.todoary.ms.util.BaseResponseStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
-
-import javax.servlet.http.HttpServletRequest;
-
-import static com.todoary.ms.util.ErrorLogWriter.writeExceptionWithRequest;
 
 
 @Slf4j
@@ -103,7 +96,7 @@ public class JpaAuthController {
      * @return 결과 메세지
      */
     @PostMapping("/signup")
-    public BaseResponse<String> joinNormalMember(@RequestBody MemberJoinRequest memberJoinRequest) {
+    public BaseResponse<BaseResponseStatus> joinNormalMember(@RequestBody MemberJoinRequest memberJoinRequest) {
         String encodedPassword = memberService.encodePassword(memberJoinRequest.getPassword());
         MemberJoinParam memberJoinParam = new MemberJoinParam(
                 memberJoinRequest.getName(),
@@ -111,7 +104,7 @@ public class JpaAuthController {
                 memberJoinRequest.getEmail(),
                 encodedPassword,
                 "ROLE_USER",
-                memberJoinRequest.isTermsEnable()
+                memberJoinRequest.getIsTermsEnable()
         );
         memberService.join(memberJoinParam);
         return new BaseResponse<>(BaseResponseStatus.SUCCESS);

--- a/src/main/java/com/todoary/ms/src/web/controller/JpaCategoryController.java
+++ b/src/main/java/com/todoary/ms/src/web/controller/JpaCategoryController.java
@@ -18,7 +18,7 @@ import static com.todoary.ms.util.BaseResponseStatus.SUCCESS;
 @Slf4j
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/v2/category")
+@RequestMapping("/jpa/category")
 public class JpaCategoryController {
 
     private final JpaCategoryService categoryService;

--- a/src/main/java/com/todoary/ms/src/web/controller/JpaTestController.java
+++ b/src/main/java/com/todoary/ms/src/web/controller/JpaTestController.java
@@ -1,0 +1,109 @@
+package com.todoary.ms.src.web.controller;
+
+import com.todoary.ms.src.auth.jwt.JwtTokenProvider;
+import com.todoary.ms.src.web.dto.*;
+import com.todoary.ms.util.BaseResponse;
+import lombok.*;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Random;
+
+import static com.todoary.ms.util.ColumnLengthInfo.CATEGORY_TITLE_MAX_LENGTH;
+import static com.todoary.ms.util.ColumnLengthInfo.TODO_TITLE_MAX_LENGTH;
+
+@RequiredArgsConstructor
+@RestController
+@Profile({"dev", "local-rds", "local-h2"})
+@RequestMapping("/jpa/test")
+public class JpaTestController {
+
+    private final JpaAuthController authController;
+    private final JpaTodoController todoController;
+    private final JpaCategoryController categoryController;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @GetMapping("")
+    public BaseResponse<TestMemberDto> joinTestMember() {
+        TestMemberDto testMember = saveRandomMember();
+        saveRandomCategory(testMember);
+        saveRandomTodo(testMember);
+        return new BaseResponse<>(testMember);
+    }
+
+    private TestMemberDto saveRandomMember() {
+        MemberJoinRequest member = generateMemberRequest();
+        authController.joinNormalMember(member);
+        SigninResponse token = authController.login(new SigninRequest(member.getEmail(), member.getPassword())).getResult();
+        Long memberId = Long.parseLong(jwtTokenProvider.getUserIdFromAccessToken(token.getAccessToken()));
+        return new TestMemberDto(memberId, member, token);
+    }
+
+    private void saveRandomCategory(TestMemberDto testMember) {
+        CategoryRequest request = new CategoryRequest(generateNumeralOrLetters(CATEGORY_TITLE_MAX_LENGTH), new Random().nextInt(10) + 1);
+        CategorySaveResponse response = categoryController.createCategory(testMember.memberId, request).getResult();
+        testMember.categoryId = response.getCategoryId();
+        testMember.category = request;
+    }
+
+    private void saveRandomTodo(TestMemberDto testMember) {
+        TodoRequest request = TodoRequest.builder()
+                .title(generateNumeralOrLetters(TODO_TITLE_MAX_LENGTH))
+                .targetTime(LocalTime.now())
+                .targetDate(LocalDate.now())
+                .categoryId(testMember.categoryId)
+                .isAlarmEnabled(true)
+                .build();
+        TodoSaveResponse response = todoController.createTodo(testMember.memberId, request).getResult();
+        testMember.todoId = response.getTodoId();
+        testMember.todo = request;
+    }
+
+    private MemberJoinRequest generateMemberRequest() {
+        int maxNicknameLength = 10;
+        String nickname = generateNumeralOrLetters(maxNicknameLength);
+        return MemberJoinRequest.builder()
+                .name(nickname)
+                .nickname(nickname)
+                .email(nickname + "@gmail.com")
+                .password("1234")
+                .isTermsEnable(true)
+                .build();
+    }
+
+    private String generateNumeralOrLetters(int length) {
+        // 아스키 코드 48 ~ 122까지 랜덤 문자
+        // 예: qOji6mPStx
+        int leftLimit = 48; // numeral '0'
+        int rightLimit = 122; // letter 'z'
+        Random random = new Random();
+        return  random.ints(leftLimit, rightLimit + 1)
+                .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97)) // 아스키코드 숫자 알파벳 중간에 섞여있는 문자들 제거
+                .limit(length)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+    }
+
+    @NoArgsConstructor
+    @Getter
+    @ToString
+    private static class TestMemberDto {
+        private SigninResponse token;
+        private Long memberId;
+        private Long categoryId;
+        private Long todoId;
+        private MemberJoinRequest member;
+        private CategoryRequest category;
+        private TodoRequest todo;
+
+        public TestMemberDto(Long memberId, MemberJoinRequest member, SigninResponse token) {
+            this.memberId = memberId;
+            this.member = member;
+            this.token = token;
+        }
+    }
+}

--- a/src/main/java/com/todoary/ms/src/web/controller/JpaTodoController.java
+++ b/src/main/java/com/todoary/ms/src/web/controller/JpaTodoController.java
@@ -2,13 +2,11 @@ package com.todoary.ms.src.web.controller;
 
 import com.todoary.ms.src.config.auth.LoginMember;
 import com.todoary.ms.src.service.todo.JpaTodoService;
-import com.todoary.ms.src.web.dto.TodoSaveResponse;
-import com.todoary.ms.src.web.dto.TodoAlarmRequest;
-import com.todoary.ms.src.web.dto.TodoRequest;
-import com.todoary.ms.src.web.dto.TodoResponse;
+import com.todoary.ms.src.web.dto.*;
 import com.todoary.ms.util.BaseResponse;
 import com.todoary.ms.util.BaseResponseStatus;
 import lombok.*;
+import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,7 +20,7 @@ import static com.todoary.ms.util.BaseResponseStatus.SUCCESS;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v2/todo")
+@RequestMapping("/jpa/todo")
 public class JpaTodoController {
     private final JpaTodoService todoService;
 
@@ -117,6 +115,19 @@ public class JpaTodoController {
     ) {
         todoService.updateTodoAlarm(memberId, todoId, request);
         return BaseResponse.from(SUCCESS);
+    }
+
+    // 3.10 페이징 적용하여 카테고리별 투두 조회
+    // * 오늘 날짜 이전은 포함하지 않는다
+    // ?page=0&size=5
+    // 만약 파라미터가 넘어오지 않으면 기본값으로 세팅됨(Page request [number: 0, size 20, sort: UNSORTED])
+    @GetMapping("/category/{categoryId}/page")
+    public BaseResponse<PageResponse<TodoResponse>> retrieveTodoPageByCategoryStartingToday(
+            @LoginMember Long memberId,
+            @PathVariable("categoryId") Long categoryId,
+            Pageable pageable
+    ) {
+        return new BaseResponse<>(todoService.findTodoPageByCategory(pageable, memberId, categoryId));
     }
 
     @ToString

--- a/src/main/java/com/todoary/ms/src/web/dto/MemberJoinRequest.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/MemberJoinRequest.java
@@ -12,5 +12,6 @@ public class MemberJoinRequest {
     private String nickname;
     private String email;
     private String password;
-    private Boolean isTermsEnable;
+    @Builder.Default
+    private Boolean isTermsEnable = true;
 }

--- a/src/main/java/com/todoary/ms/src/web/dto/MemberJoinRequest.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/MemberJoinRequest.java
@@ -1,20 +1,16 @@
 package com.todoary.ms.src.web.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @ToString
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class MemberJoinRequest {
     private String name;
     private String nickname;
     private String email;
     private String password;
-    @JsonProperty("isTermsEnable")
-    private boolean isTermsEnable;
+    private Boolean isTermsEnable;
 }

--- a/src/main/java/com/todoary/ms/src/web/dto/PageResponse.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/PageResponse.java
@@ -1,0 +1,40 @@
+package com.todoary.ms.src.web.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PageResponse<T> {
+    private List<T> content;
+    private PageInfo pageable;
+
+    public PageResponse(List<T> content, PageInfo pageable) {
+        this.content = content;
+        this.pageable = pageable;
+    }
+
+    public static <T> PageResponse<T> of(Page<T> pagedResult) {
+        return new PageResponse<>(
+                pagedResult.getContent(),
+                PageInfo.builder()
+                        .pageNumber(pagedResult.getNumber())
+                        .empty(pagedResult.isEmpty())
+                        .last(pagedResult.isLast())
+                        .build()
+        );
+    }
+
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Builder
+    public static class PageInfo {
+        private int pageNumber; // 현재 페이지 번호 (0번부터 시작)
+        private boolean empty = false; // 빈 값인지
+        private boolean last = false; // 마지막 페이지인지
+    }
+}

--- a/src/main/java/com/todoary/ms/src/web/dto/PageResponse.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/PageResponse.java
@@ -1,24 +1,22 @@
 package com.todoary.ms.src.web.dto;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
-import org.springframework.data.domain.Page;
+import lombok.*;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class PageResponse<T> {
-    private List<T> content;
-    private PageInfo pageable;
+    private List<T> contents;
+    private PageInfo pageInfo;
 
-    public PageResponse(List<T> content, PageInfo pageable) {
-        this.content = content;
-        this.pageable = pageable;
+    private PageResponse(List<T> contents, PageInfo pageInfo) {
+        this.contents = contents;
+        this.pageInfo = pageInfo;
     }
 
-    public static <T> PageResponse<T> of(Page<T> pagedResult) {
+    public static <T> PageResponse<T> of(Slice<T> pagedResult) {
         return new PageResponse<>(
                 pagedResult.getContent(),
                 PageInfo.builder()
@@ -30,11 +28,12 @@ public class PageResponse<T> {
     }
 
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    @AllArgsConstructor
-    @Builder
+    @AllArgsConstructor @Builder
+    @Getter
+    @ToString
     public static class PageInfo {
         private int pageNumber; // 현재 페이지 번호 (0번부터 시작)
-        private boolean empty = false; // 빈 값인지
-        private boolean last = false; // 마지막 페이지인지
+        private boolean empty; // 빈 값인지
+        private boolean last; // 마지막 페이지인지
     }
 }

--- a/src/main/java/com/todoary/ms/src/web/dto/TodoRequest.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/TodoRequest.java
@@ -1,7 +1,6 @@
 package com.todoary.ms.src.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.todoary.ms.src.domain.Category;
 import com.todoary.ms.src.domain.Member;
 import com.todoary.ms.src.domain.Todo;
@@ -24,7 +23,7 @@ public class TodoRequest {
     @Length(max = TODO_TITLE_MAX_LENGTH, message="TODO_TITLE_TOO_LONG")
     private String title;
 
-    @JsonProperty("isAlarmEnabled")
+    @Builder.Default
     private Boolean isAlarmEnabled = false;
 
     @NotNull(message="EMPTY_TODO_DATE")

--- a/src/main/java/com/todoary/ms/src/web/dto/TodoRequest.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/TodoRequest.java
@@ -1,5 +1,6 @@
 package com.todoary.ms.src.web.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.todoary.ms.src.domain.Category;
 import com.todoary.ms.src.domain.Member;
@@ -24,13 +25,15 @@ public class TodoRequest {
     private String title;
 
     @JsonProperty("isAlarmEnabled")
-    private boolean isAlarmEnabled;
+    private Boolean isAlarmEnabled = false;
 
     @NotNull(message="EMPTY_TODO_DATE")
     @DateTimeFormat(pattern="yyyy-MM-dd")
+    @JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     private LocalDate targetDate;
 
     @DateTimeFormat(pattern="HH:mm")
+    @JsonFormat(pattern = "HH:mm", timezone = "Asia/Seoul")
     private LocalTime targetTime;
 
     @NotNull(message="USERS_CATEGORY_NOT_EXISTS")
@@ -38,8 +41,8 @@ public class TodoRequest {
 
     public Todo toEntity(Member member, Category category) {
         return Todo.builder()
-                .title(getTitle())
-                .isAlarmEnabled(isAlarmEnabled())
+                .title(title)
+                .isAlarmEnabled(isAlarmEnabled)
                 .category(category)
                 .member(member)
                 .targetDate(targetDate)

--- a/src/test/java/com/todoary/ms/src/web/controller/JpaCategoryControllerTest.java
+++ b/src/test/java/com/todoary/ms/src/web/controller/JpaCategoryControllerTest.java
@@ -184,7 +184,7 @@ class JpaCategoryControllerTest {
     }
 
     private static class REQUEST_URL {
-        public static String BASE = "/v2/category";
+        public static String BASE = "/jpa/category";
         public static String SAVE = BASE;
         public static String UPDATE = BASE + "/{categoryId}";
         public static String RETRIEVE = BASE;

--- a/src/test/java/com/todoary/ms/src/web/controller/TestUtils.java
+++ b/src/test/java/com/todoary/ms/src/web/controller/TestUtils.java
@@ -3,6 +3,7 @@ package com.todoary.ms.src.web.controller;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todoary.ms.src.web.dto.PageResponse;
 import com.todoary.ms.util.BaseResponse;
 import com.todoary.ms.util.BaseResponseStatus;
 import org.springframework.test.web.servlet.MvcResult;
@@ -34,4 +35,13 @@ class TestUtils {
         BaseResponse<List<T>> response = objectMapper.readValue(json, javaType);
         return response.getResult();
     }
+
+    static <T> PageResponse<T> getPageResponse(MvcResult result, Class<T> type, ObjectMapper objectMapper) throws JsonProcessingException, UnsupportedEncodingException {
+        JavaType pageType = objectMapper.getTypeFactory().constructParametricType(PageResponse.class, type);
+        JavaType javaType = objectMapper.getTypeFactory().constructParametricType(BaseResponse.class, pageType);
+        String json = result.getResponse().getContentAsString();
+        BaseResponse<PageResponse<T>> response = objectMapper.readValue(json, javaType);
+        return response.getResult();
+    }
+
 }


### PR DESCRIPTION
## What is this PR? 🔍
- 카테고리로 투두 조회시 많은 양의 투두가 조회되므로 페이징 적용합니다.

## Changes 📝

### 페이징 적용한 카테고리 투두 조회 api 추가
페이징 적용 안한 api도 아직 필요할 것 같아서 둘 다 나뒀습니다.

### Scheduling release에서만 활성화
지금 JDBC랑 JPA가 섞여있는데 Sceduling으로 JDBC 코드가 호출될 때 오류가 발생하고 있어서 우선 Scheduling을 release에서만 활성화하게 했습니다. 나중에 구현 후 dev도 `SchedulingConfig` 에 추가해야 합니다. 로컬에서 테스트 필요할 때도 추가해주세요~

### API 테스트용 멤버
- `/jpa/test` 요청으로 테스트용 멤버 새로 생성

  이건 꼭 필요한 건 아닌데 클라이언트나 저희가 api로 테스트할 때 쓸 수 있을 거 같아서 만들었습니다.
  멤버 회원가입 후 카테고리/투두 하나씩 생성한 후에 토큰 포함 새로운 정보들 모두 리턴하게 만들었습니다.
  Profile에 따라서 활성화하도록 해서 dev나 local 프로파일에서만 api 실행할 수 있습니다.

### boolean → Boolean
dto에서 is가 붙은 boolean 변수 사용 시에 @JsonProperty추가해도 한번 더 설정해주지 않으면 is와 is안붙은 변수로 두값이 생기게 됩니다. 돌아가는 데 문제는 없지만 그래도 하나로 남는 게 나을 것 같아서 Boolean으로 변경했습니다.
그리고 Boolean이랑 builder같이 쓸 때 Builder Default값 설정 빼먹는거 조심해주세요~

## Test Checklist ☑️
- [X] 페이징 파라미터 적용했을 때 조회
- [X] 페이징 파라미터 적용 안했을 때 기본값으로 조회

## To Reviewers 📢
- boolean → Boolean은 한 번만 읽어주세용
