### PR TITLE
feat: 프로필 이미지 관련 정보 yml로 설정해서 주입받는다

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "config"]
 	path = config
 	url = https://github.com/Todoary/Server-Config.git
+	branch = master

--- a/build.gradle
+++ b/build.gradle
@@ -99,9 +99,8 @@ task copyTestResources {
     doLast {
         println '*********** test copy start ***********'
         copy {
-            from './config/application-local-h2.yml'
+            from './config/application-local-h2.yml', './config/application.yml'
             into './src/test/resources'
-            rename 'application-local-h2.yml', 'application.yml'
         }
         println '*********** test copy end *************'
     }

--- a/src/main/java/com/todoary/ms/src/constant/MemberConstants.java
+++ b/src/main/java/com/todoary/ms/src/constant/MemberConstants.java
@@ -1,7 +1,0 @@
-package com.todoary.ms.src.constant;
-
-public final class MemberConstants {
-    public static final String MEMBER_DEFAULT_PROFILE_IMG_URL =
-            "https://todoarybucket.s3.ap-northeast-2.amazonaws.com/todoary/users/admin/default_profile_img.jpg";
-
-}

--- a/src/main/java/com/todoary/ms/src/domain/Member.java
+++ b/src/main/java/com/todoary/ms/src/domain/Member.java
@@ -8,8 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,7 +28,7 @@ public class Member extends BaseTimeEntity{
     private String password;
 
     @Column(name = "profile_img_url")
-    private String profileImgUrl = "https://todoarybucket.s3.ap-northeast-2.amazonaws.com/todoary/users/admin/default_profile_img.jpg";
+    private String profileImgUrl;
 
     private String introduce;
 
@@ -70,7 +68,7 @@ public class Member extends BaseTimeEntity{
     /*---Constructor---*/
 
     @Builder
-    public Member(String name, String nickname, String email, String password, String role, ProviderAccount providerAccount, Boolean isTermsEnable) {
+    public Member(String name, String nickname, String email, String password, String role, ProviderAccount providerAccount, Boolean isTermsEnable, String profileImgUrl) {
         this.name = name;
         this.nickname = nickname;
         this.email = email;
@@ -78,6 +76,7 @@ public class Member extends BaseTimeEntity{
         this.role = role;
         this.providerAccount = providerAccount;
         this.isTermsEnable = isTermsEnable;
+        this.profileImgUrl = profileImgUrl;
     }
 
     /*---Setter---*/

--- a/src/main/java/com/todoary/ms/src/exception/common/ExceptionController.java
+++ b/src/main/java/com/todoary/ms/src/exception/common/ExceptionController.java
@@ -1,5 +1,6 @@
 package com.todoary.ms.src.exception.common;
 
+import com.amazonaws.AmazonServiceException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.todoary.ms.util.BaseResponse;
 import com.todoary.ms.util.BaseResponseStatus;
@@ -63,6 +64,12 @@ public class ExceptionController {
         }
         return ResponseEntity.ok()
                 .body(BaseResponse.from(ILLEGAL_ARGUMENT));
+    }
+
+    @ExceptionHandler(AmazonServiceException.class)
+    private ResponseEntity<BaseResponse<BaseResponseStatus>> handleS3Request(AmazonServiceException exception) {
+        return ResponseEntity.ok()
+                .body(BaseResponse.from(AWS_ACCESS_DENIED));
     }
 
     @ExceptionHandler({Exception.class})

--- a/src/main/java/com/todoary/ms/src/service/MemberService.java
+++ b/src/main/java/com/todoary/ms/src/service/MemberService.java
@@ -7,6 +7,7 @@ import com.todoary.ms.src.exception.common.TodoaryException;
 import com.todoary.ms.src.repository.MemberRepository;
 import com.todoary.ms.src.web.dto.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,9 @@ public class MemberService {
 
     private final PasswordEncoder passwordEncoder;
 
+    @Value("${profile-image.default-url}")
+    private String defaultProfileImageUrl;
+
     @Transactional
     public Long join(MemberJoinParam memberJoinParam) {
         Member newMember = Member.builder()
@@ -33,6 +37,7 @@ public class MemberService {
                 .role(memberJoinParam.getRole())
                 .providerAccount(new ProviderAccount(Provider.NONE, "none"))
                 .isTermsEnable(memberJoinParam.isTermsEnable())
+                .profileImgUrl(defaultProfileImageUrl)
                 .build();
         init(newMember);
         return memberRepository.save(newMember);
@@ -99,9 +104,9 @@ public class MemberService {
     }
 
     @Transactional
-    public Member findProfileById(Long memberId) {
-        return memberRepository.findProfileById(memberId)
-                .orElseThrow(() -> new TodoaryException(USERS_DELETED_USER));
+    public MemberResponse findProfileById(Long memberId) {
+        return MemberResponse.from(memberRepository.findProfileById(memberId)
+                .orElseThrow(() -> new TodoaryException(USERS_DELETED_USER)));
     }
 
     @Transactional

--- a/src/main/java/com/todoary/ms/src/user/UserController.java
+++ b/src/main/java/com/todoary/ms/src/user/UserController.java
@@ -109,7 +109,7 @@ public class UserController {
                 return new BaseResponse<>("삭제에 성공하였습니다.");
 
             filekey = userProvider.retrieveById(user_id).getProfile_img_url().substring(54);
-            result = awsS3Service.fileDelete(filekey);
+            awsS3Service.fileDelete(filekey);
             userService.modifyProfileImgToDefault(user_id);
             return new BaseResponse<>("삭제에 성공하였습니다.");
         } catch (BaseException e) {

--- a/src/main/java/com/todoary/ms/src/web/controller/JpaMemberController.java
+++ b/src/main/java/com/todoary/ms/src/web/controller/JpaMemberController.java
@@ -2,22 +2,19 @@ package com.todoary.ms.src.web.controller;
 
 
 import com.todoary.ms.src.config.auth.LoginMember;
-import com.todoary.ms.src.constant.MemberConstants;
 import com.todoary.ms.src.domain.Member;
 import com.todoary.ms.src.s3.AwsS3Service;
-import com.todoary.ms.src.s3.dto.PostProfileImgRes;
 import com.todoary.ms.src.service.MemberService;
-import com.todoary.ms.src.web.dto.*;
-import com.todoary.ms.util.BaseException;
+import com.todoary.ms.src.web.dto.MemberProfileImgUrlResponse;
+import com.todoary.ms.src.web.dto.MemberProfileRequest;
+import com.todoary.ms.src.web.dto.MemberResponse;
 import com.todoary.ms.util.BaseResponse;
 import com.todoary.ms.util.BaseResponseStatus;
-import com.todoary.ms.util.ErrorLogWriter;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
@@ -49,11 +46,7 @@ public class JpaMemberController {
             @RequestPart("profile-img") MultipartFile multipartFile
     ) {
         String memberProfileImgUrl = memberService.getProfileImgUrlById(memberId);
-
-        if (!memberProfileImgUrl.equals(MemberConstants.MEMBER_DEFAULT_PROFILE_IMG_URL)) {
-            awsS3Service.fileDelete(memberProfileImgUrl.substring(54));
-        }
-
+        awsS3Service.fileDelete(memberProfileImgUrl);
         String newProfileImgUrl = awsS3Service.upload(multipartFile, memberId);
         memberService.changeProfileImg(memberId, newProfileImgUrl);
         return new BaseResponse<>(new MemberProfileImgUrlResponse(memberId, newProfileImgUrl));
@@ -67,7 +60,7 @@ public class JpaMemberController {
 
     // 2.4 프로필 조회 api
     @GetMapping("")
-    public BaseResponse<Member> retrieveMember(@LoginMember Long memberId) {
+    public BaseResponse<MemberResponse> retrieveMember(@LoginMember Long memberId) {
         return new BaseResponse<>(memberService.findProfileById(memberId));
     }
 

--- a/src/main/java/com/todoary/ms/src/web/dto/MemberProfileImgUrlResponse.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/MemberProfileImgUrlResponse.java
@@ -3,10 +3,12 @@ package com.todoary.ms.src.web.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class MemberProfileImgUrlResponse {
     private Long memberId;
     private String profileImgUrl;

--- a/src/main/java/com/todoary/ms/src/web/dto/MemberResponse.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/MemberResponse.java
@@ -1,6 +1,7 @@
 package com.todoary.ms.src.web.dto;
 
 
+import com.todoary.ms.src.domain.Member;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,4 +17,8 @@ public class MemberResponse {
     private String nickname;
     private String introduce;
     private String email;
+
+    public static MemberResponse from(Member member) {
+        return new MemberResponse(member.getProfileImgUrl(), member.getNickname(), member.getIntroduce(), member.getEmail());
+    }
 }

--- a/src/test/java/com/todoary/ms/src/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/todoary/ms/src/repository/MemberRepositoryTest.java
@@ -5,17 +5,17 @@ import com.todoary.ms.src.domain.Provider;
 import com.todoary.ms.src.domain.ProviderAccount;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
-
 import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Transactional
 @SpringBootTest
@@ -25,6 +25,9 @@ class MemberRepositoryTest {
 
     @Autowired
     EntityManager em;
+
+    @Value("${profile-image.default-url}")
+    private String defaultProfileImageUrl;
 
     @Test
     public void 멤버를_이메일과_provider로_검색_유저_존재O() throws Exception {

--- a/src/test/java/com/todoary/ms/src/s3/AwsS3ServiceTest.java
+++ b/src/test/java/com/todoary/ms/src/s3/AwsS3ServiceTest.java
@@ -1,0 +1,84 @@
+package com.todoary.ms.src.s3;
+
+import com.todoary.ms.src.exception.common.TodoaryException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.todoary.ms.util.BaseResponseStatus.AWS_FILE_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class AwsS3ServiceTest {
+
+    @Autowired
+    private AwsS3Service awsS3Service;
+
+    @Value("${profile-image.default-url}")
+    private String defaultProfileImageUrl;
+
+    @Value("${profile-image.filename-pattern}")
+    private String fileNamePatternExp;
+
+    private Pattern fileNamePattern;
+
+    @BeforeEach
+    void setup() {
+        fileNamePattern = Pattern.compile(fileNamePatternExp);
+    }
+
+    @Test
+    void 기본_프로필_이미지는_삭제X() {
+        // when
+        boolean deleted = awsS3Service.fileDelete(defaultProfileImageUrl);
+        // then
+        assertThat(deleted).isFalse();
+    }
+
+    @Test
+    void url_유효하지_않을때_파일_삭제X() {
+        // given
+        String fileUrl = "12345";
+        // when
+        assertThatThrownBy(() -> awsS3Service.fileDelete(fileUrl))
+                .isInstanceOf(TodoaryException.class)
+                .matches(e -> ((TodoaryException) e).getStatus().equals(AWS_FILE_NOT_FOUND));
+    }
+
+    @Test
+    void 없는_파일일때_파일_삭제X() {
+        //given
+        Matcher matcher = fileNamePattern.matcher(defaultProfileImageUrl);
+        assertThat(matcher.matches()).isTrue();
+
+        String fileUrlPrefix = matcher.group(1);
+        String fileUrl = fileUrlPrefix + "12345";
+        System.out.println("fileUrl = " + fileUrl);
+        // when
+        assertThatThrownBy(() -> awsS3Service.fileDelete(fileUrl))
+                .isInstanceOf(TodoaryException.class)
+                .matches(e -> ((TodoaryException) e).getStatus().equals(AWS_FILE_NOT_FOUND));
+    }
+
+    @Test
+    void 기본_프로필이름_파싱() {
+        // given
+        Matcher matcher = fileNamePattern.matcher(defaultProfileImageUrl);
+        assertThat(matcher.matches()).isTrue();
+        System.out.println("matcher = " + matcher);
+        System.out.println("matcher.group(0) = " + matcher.group(0));
+        System.out.println("matcher.group(1) = " + matcher.group(1));
+        System.out.println("matcher.group(2) = " + matcher.group(2));
+        // when
+        String fileName = awsS3Service.getFileName(defaultProfileImageUrl);
+        System.out.println("fileName = " + fileName);
+        // then
+        assertThat(fileName).isEqualTo(matcher.group(2));
+    }
+}

--- a/src/test/java/com/todoary/ms/src/service/MemberServiceTest.java
+++ b/src/test/java/com/todoary/ms/src/service/MemberServiceTest.java
@@ -6,11 +6,11 @@ import com.todoary.ms.src.repository.MemberRepository;
 import com.todoary.ms.src.web.dto.MemberJoinParam;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
-
 import java.util.List;
 
 import static com.todoary.ms.src.domain.Category.InitialCategoryValue.initialColor;
@@ -22,12 +22,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MemberServiceTest {
     @Autowired
     EntityManager em;
-
     @Autowired
     MemberService memberService;
 
     @Autowired
     MemberRepository memberRepository;
+
+    @Value("${profile-image.default-url}")
+    private String defaultProfileImageUrl;
 
     @Test
     public void 멤버_회원가입() throws Exception {
@@ -55,12 +57,23 @@ class MemberServiceTest {
         assertThat(categories.get(0).getMember().getId()).isEqualTo(joinMemberId);
     }
 
+    @Test
+    void 멤버_생성시_기본이미지_있어야함O() {
+        // given
+        MemberJoinParam memberJoinParam = createMemberJoinParam();
+        // when
+        Long joinMemberId = memberService.join(memberJoinParam);
+        String profileImgUrl = memberService.findById(joinMemberId).getProfileImgUrl();
+        // then
+        assertThat(profileImgUrl).isEqualTo(defaultProfileImageUrl);
+    }
+
     MemberJoinParam createMemberJoinParam() {
         return new MemberJoinParam("memberA",
-                "nicknameA",
-                "emailA",
-                "passwordA",
-                "ROLE_USER",
-                true);
+                                   "nicknameA",
+                                   "emailA",
+                                   "passwordA",
+                                   "ROLE_USER",
+                                   true);
     }
 }

--- a/src/test/java/com/todoary/ms/src/web/controller/JpaMemberControllerTest.java
+++ b/src/test/java/com/todoary/ms/src/web/controller/JpaMemberControllerTest.java
@@ -1,24 +1,19 @@
 package com.todoary.ms.src.web.controller;
 
 import com.todoary.ms.src.config.auth.WithTodoaryMockUser;
-import com.todoary.ms.src.constant.MemberConstants;
 import com.todoary.ms.src.s3.AwsS3Service;
 import com.todoary.ms.src.service.MemberService;
 import com.todoary.ms.src.web.dto.MemberProfileImgUrlResponse;
 import com.todoary.ms.util.BaseResponseStatus;
-
 import org.junit.jupiter.api.Test;
-
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-
 import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,12 +21,13 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 
-import static com.todoary.ms.src.web.controller.TestUtils.*;
-import static org.assertj.core.api.Assertions.*;
+import static com.todoary.ms.src.web.controller.TestUtils.getResponseObject;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Transactional
 @SpringBootTest
@@ -46,12 +42,15 @@ class JpaMemberControllerTest {
     @MockBean
     MemberService memberService;
 
+    @Value("${profile-image.default-url}")
+    private String defaultProfileImgUrl;
+
     @Test
     @WithTodoaryMockUser
     void 기본_프로필일때_프로필_사진_수정_테스트() throws Exception {
         //given
         when(awsS3Service.upload(any(), anyLong())).thenReturn("mockingImgUrl");
-        when(memberService.getProfileImgUrlById(anyLong())).thenReturn(MemberConstants.MEMBER_DEFAULT_PROFILE_IMG_URL);
+        when(memberService.getProfileImgUrlById(anyLong())).thenReturn(defaultProfileImgUrl);
 
         String fileName = "testImage"; //파일명
         String contentType = "png"; //파일타입
@@ -90,7 +89,7 @@ class JpaMemberControllerTest {
         //given
         when(awsS3Service.upload(any(), anyLong())).thenReturn("mockingImgUrl");
         when(memberService.getProfileImgUrlById(anyLong()))
-                .thenReturn(MemberConstants.MEMBER_DEFAULT_PROFILE_IMG_URL + "/modified");
+                .thenReturn(defaultProfileImgUrl + "/modified");
 
         String fileName = "testImage"; //파일명
         String contentType = "png"; //파일타입


### PR DESCRIPTION
## What is this PR? 🔍
- S3에 저장된 프로필 기본 이미지 관련 정보가 그냥 raw string으로 여러곳에 있길래 yaml로 설정하고 주입받도록 변경했습니다.
  앞으로 S3 바뀌면 어차피 url 바꿔야 되니까 yaml로 설정하면 겸사겸사 편할 것 같습니다.
- 근데 빈이 아니면 yaml값을 받을 수가 없어서 MemberService에서 join시에 url 넣어주도록 했습니다. 음.. 그래서 Service에서 넣어주는 게 맞나 생각했는데 기본 이미지 url이 있다는 건 어차피 Member보단 MemberService가 알고 있는 게 맞지 않을까요?

## Changes 📝
- 기본 이미지 url 사용하는 곳 모두 주입받도록 함
- 프로필 이미지 url에서 파일 이름 추출할 때 substring(54)으로 하드코딩 되어 있는 것도 url 변경되면 문제 생길 것 같아 정규식 기반으로 파싱함
- 멤버 프로필 조회시 Dto가 아닌 엔티티 전체 응답하던 것 Dto하도록함

## Test Checklist ☑️
- [X] 기본_프로필_이미지는_삭제X
- [X] url_유효하지_않을때_파일_삭제X
- [X] 없는_파일일때_파일_삭제X
- [X] 기본_프로필이름_파싱
- [X] 멤버_생성시_기본이미지_있어야함O

## To Reviewers 📢
- @60jong S3 관련 테스트가 없는 거 같은데 제가 추가한 테스트는 파일 이름 파싱하는 정도만 확인했습니다. 일단 일기를 먼저 해야해서 나머지는 지금 못보겠네요.. 변경한 부분 문제 없는지 한번 봐주세요~!

