### PR TITLE
Feature/auth/apple

### DIFF
--- a/src/main/java/com/todoary/ms/src/common/auth/PrincipalDetailsService.java
+++ b/src/main/java/com/todoary/ms/src/common/auth/PrincipalDetailsService.java
@@ -16,6 +16,6 @@ public class PrincipalDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        return new PrincipalDetails(memberService.findByEmailOfGeneralMember(email));
+        return new PrincipalDetails(memberService.findGeneralMemberByEmail(email));
     }
 }

--- a/src/main/java/com/todoary/ms/src/common/auth/PrincipalOAuth2UserService.java
+++ b/src/main/java/com/todoary/ms/src/common/auth/PrincipalOAuth2UserService.java
@@ -35,7 +35,7 @@ public class PrincipalOAuth2UserService extends DefaultOAuth2UserService {
         String provider_id = (String) oAuth2User.getAttributes().get("sub");
 
         ProviderAccount providerAccount = ProviderAccount.from(provider, provider_id);
-        Member member = memberService.findByProvider(email, providerAccount);
+        Member member = memberService.findByProviderAccount(providerAccount);
 
         if (member == null) {
             System.out.println("구글 로그인 최초입니다. 회원가입을 진행합니다.");

--- a/src/main/java/com/todoary/ms/src/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/todoary/ms/src/common/response/BaseResponseStatus.java
@@ -26,6 +26,7 @@ public enum BaseResponseStatus {
     DIFFERENT_REFRESH_TOKEN(false, 2006, "유저 정보와 일치하지 않는 refresh token입니다."),
     APPLE_Client_SECRET_ERROR(false, 2007, "클라이언트 시크릿 생성에 실패하였습니다."),
     APPLE_AUTHENTICATION_CODE_VALIDATION_FAILURE(false, 20071, "APPLE 인증 코드 검증에 실패했습니다."),
+    APPLE_REVOKE_FAILURE(false, 20072, "애플 회원 탈퇴에 실패했습니다"),
     INVALID_APPLE_AUTH(false, 2008, "유효하지 않은 토큰 입니다."),
     PARSE_USER_ERROR(false, 2009, "애플 유저 조회에 실패하였습니다."),
 

--- a/src/main/java/com/todoary/ms/src/repository/MemberRepository.java
+++ b/src/main/java/com/todoary/ms/src/repository/MemberRepository.java
@@ -2,6 +2,7 @@ package com.todoary.ms.src.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.todoary.ms.src.domain.Member;
+import com.todoary.ms.src.domain.Provider;
 import com.todoary.ms.src.domain.ProviderAccount;
 import com.todoary.ms.src.domain.token.RefreshToken;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -98,15 +99,30 @@ public class MemberRepository {
                 .getResultStream().findAny();
     }
 
-    public Optional<Member> findByProvider(String email, ProviderAccount provider) {
-        return em.createQuery("select m from Member m where m.providerAccount = :provider and m.email = :email", Member.class)
+    public Optional<Member> findByProviderEmail(String email, Provider provider) {
+        return em.createQuery("select m from Member m where m.providerAccount.provider = :provider and m.email = :email", Member.class)
                 .setParameter("provider", provider)
                 .setParameter("email", email)
                 .getResultStream().findAny();
     }
 
+    public Optional<Member> findByProviderAccount(ProviderAccount providerAccount) {
+        return em.createQuery("select m from Member m where m.providerAccount = :providerAccount", Member.class)
+                .setParameter("providerAccount", providerAccount)
+                .getResultStream()
+                .findAny();
+    }
+
     public List<Member> findAllDailyAlarmEnabled() {
         return em.createQuery("select m from Member m where m.dailyAlarmEnable = true", Member.class)
                 .getResultList();
+    }
+
+    public Optional<Member> findGeneralMemberByEmail(String email) {
+        return em.createQuery("select m from Member m where m.providerAccount = :providerAccount and m.email = :email")
+                .setParameter("providerAccount", ProviderAccount.none())
+                .setParameter("email", email)
+                .getResultStream()
+                .findAny();
     }
 }

--- a/src/main/java/com/todoary/ms/src/repository/MemberRepository.java
+++ b/src/main/java/com/todoary/ms/src/repository/MemberRepository.java
@@ -99,7 +99,7 @@ public class MemberRepository {
                 .getResultStream().findAny();
     }
 
-    public Optional<Member> findByProviderEmail(String email, Provider provider) {
+    public Optional<Member> findByProviderEmail(Provider provider, String email) {
         return em.createQuery("select m from Member m where m.providerAccount.provider = :provider and m.email = :email", Member.class)
                 .setParameter("provider", provider)
                 .setParameter("email", email)

--- a/src/main/java/com/todoary/ms/src/service/MemberService.java
+++ b/src/main/java/com/todoary/ms/src/service/MemberService.java
@@ -112,6 +112,11 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
+    public Member findByProviderEmail(Provider provider, String email) {
+        return checkMemberValid(memberRepository.findByProviderEmail(provider, email));
+    }
+
+    @Transactional(readOnly = true)
     public Member findByProviderAccount(ProviderAccount providerAccount) {
         return checkMemberValid(memberRepository.findByProviderAccount(providerAccount));
     }
@@ -189,6 +194,11 @@ public class MemberService {
     @Transactional
     public void removeMember(Long memberId) {
         Member member = findById(memberId);
+        removeMember(member);
+    }
+
+    @Transactional
+    public void removeMember(Member member) {
         member.deactivate();
     }
 

--- a/src/main/java/com/todoary/ms/src/service/MemberService.java
+++ b/src/main/java/com/todoary/ms/src/service/MemberService.java
@@ -4,6 +4,7 @@ import com.todoary.ms.src.common.auth.jwt.JwtTokenProvider;
 import com.todoary.ms.src.common.exception.TodoaryException;
 import com.todoary.ms.src.domain.Category;
 import com.todoary.ms.src.domain.Member;
+import com.todoary.ms.src.domain.Provider;
 import com.todoary.ms.src.domain.ProviderAccount;
 import com.todoary.ms.src.repository.MemberRepository;
 import com.todoary.ms.src.web.dto.MemberJoinParam;
@@ -106,13 +107,13 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public Member findByEmailOfGeneralMember(String email) {
-        return checkMemberValid(memberRepository.findByProvider(email, ProviderAccount.none()));
+    public Member findGeneralMemberByEmail(String email) {
+        return checkMemberValid(memberRepository.findGeneralMemberByEmail(email));
     }
 
     @Transactional(readOnly = true)
-    public Member findByProvider(String email, ProviderAccount provider) {
-        return checkMemberValid(memberRepository.findByProvider(email, provider));
+    public Member findByProviderAccount(ProviderAccount providerAccount) {
+        return checkMemberValid(memberRepository.findByProviderAccount(providerAccount));
     }
 
     private void checkEmailAndOAuthAccountNotUsed(String email, ProviderAccount provider) {
@@ -129,7 +130,7 @@ public class MemberService {
 
     @Transactional
     public void changePassword(String email, String newPassword) {
-        Member member = findByEmailOfGeneralMember(email);
+        Member member = findGeneralMemberByEmail(email);
         member.changePassword(encodePassword(newPassword));
     }
 

--- a/src/main/java/com/todoary/ms/src/web/controller/JpaAuthController.java
+++ b/src/main/java/com/todoary/ms/src/web/controller/JpaAuthController.java
@@ -1,5 +1,6 @@
 package com.todoary.ms.src.web.controller;
 
+import com.todoary.ms.src.domain.Member;
 import com.todoary.ms.src.domain.Provider;
 import com.todoary.ms.src.domain.ProviderAccount;
 import com.todoary.ms.src.domain.token.AccessToken;
@@ -173,11 +174,15 @@ public class JpaAuthController {
 
     @PostMapping("/revoke/apple")
     public BaseResponse<BaseResponseStatus> appleRevoke(@RequestBody AppleRevokeRequest appleRevokeRequest) {
-        // revoke with Apple
+        // revoke from Apple
         JSONObject tokenResponse = appleAuthService.getTokenResponseByCode(appleRevokeRequest.getCode());
         String appleRefreshToken = tokenResponse.getAsString("refresh_token");
 
         appleAuthService.revoke(appleRefreshToken);
+
+        // revoke from Todoary
+        Member member = memberService.findByProviderEmail(Provider.APPLE, appleRevokeRequest.getEmail());
+        memberService.removeMember(member);
 
         return new BaseResponse<>(SUCCESS);
     }

--- a/src/main/java/com/todoary/ms/src/web/controller/JpaAuthController.java
+++ b/src/main/java/com/todoary/ms/src/web/controller/JpaAuthController.java
@@ -129,8 +129,8 @@ public class JpaAuthController {
         return new BaseResponse<>(BaseResponseStatus.SUCCESS);
     }
 
-    @PostMapping("/apple/signin")
-    public BaseResponse<AppleSigninResponse> apple(@RequestBody AppleSigninRequest appleSigninRequest) {
+    @PostMapping("/apple/token")
+    public BaseResponse<AppleSigninResponse> appleSignin(@RequestBody AppleSigninRequest appleSigninRequest) {
         // validate code
         JSONObject tokenResponse = appleAuthService.getTokenResponseByCode(appleSigninRequest.getCode());
 

--- a/src/main/java/com/todoary/ms/src/web/dto/AppleRevokeRequest.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/AppleRevokeRequest.java
@@ -1,0 +1,13 @@
+package com.todoary.ms.src.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppleRevokeRequest {
+    private String email;
+    private String code;
+}

--- a/src/test/java/com/todoary/ms/src/service/MemberServiceTest.java
+++ b/src/test/java/com/todoary/ms/src/service/MemberServiceTest.java
@@ -89,7 +89,7 @@ class MemberServiceTest {
         MemberJoinParam memberJoinParam = createMemberJoinParamOfEmail(email);
         memberService.joinGeneralMember(memberJoinParam);
         // when
-        Member member = memberService.findByEmailOfGeneralMember(email);
+        Member member = memberService.findGeneralMemberByEmail(email);
         // then
         assertThat(member.getEmail()).isEqualTo(email);
         assertThat(ProviderAccount.none()).isEqualTo(ProviderAccount.none());

--- a/src/test/java/com/todoary/ms/src/web/controller/AuthControllerTest.java
+++ b/src/test/java/com/todoary/ms/src/web/controller/AuthControllerTest.java
@@ -180,22 +180,12 @@ class AuthControllerTest {
                 true
         );
 
-        AppleSigninResponse expected = new AppleSigninResponse(
-                true,
-                "name",
-                "email",
-                ProviderAccount.appleFrom("providerId"),
-                "accessToken",
-                "refreshToken",
-                "appleRefreshToken"
-        );
-
         Map<String, String> tokenResponse = new HashMap<>();
         tokenResponse.put("id_token", "idToken");
         tokenResponse.put("refresh_token", "appleRefreshToken");
 
         when(memberService.existsByProviderAccount(any())).thenReturn(false);
-        when(memberService.findByProvider(any(), any())).thenReturn(createMemberWithId(1L));
+        when(memberService.findByProviderAccount(any())).thenReturn(createMemberWithId(1L));
         when(memberService.joinOauthMember(any())).thenReturn(1L);
         when(authService.issueAccessToken(anyLong())).thenReturn(new AccessToken("accessToken"));
         when(authService.issueRefreshToken(anyLong())).thenReturn(new RefreshToken(Member.builder().build(), "refreshToken"));
@@ -205,10 +195,11 @@ class AuthControllerTest {
 
         //when
         mockMvc.perform(
-                        post("/auth/jpa/apple/signin")
+                        post("/auth/jpa/apple/token")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(new ObjectMapper().writeValueAsString(appleSigninRequest)))
                 .andExpect(status().isOk())
+                .andDo(print())
                 .andExpect(jsonPath("$.code").value("1000"))
                 .andExpect(jsonPath("$.result.isNewUser").value(true));
     }
@@ -224,22 +215,12 @@ class AuthControllerTest {
                 true
         );
 
-        AppleSigninResponse expected = new AppleSigninResponse(
-                false,
-                "name",
-                "email",
-                ProviderAccount.appleFrom("providerId"),
-                "accessToken",
-                "refreshToken",
-                "appleRefreshToken"
-        );
-
         Map<String, String> tokenResponse = new HashMap<>();
         tokenResponse.put("id_token", "idToken");
         tokenResponse.put("refresh_token", "appleRefreshToken");
 
         when(memberService.existsByProviderAccount(any())).thenReturn(true);
-        when(memberService.findByProvider(any(), any())).thenReturn(createMemberWithId(1L));
+        when(memberService.findByProviderAccount(any())).thenReturn(createMemberWithId(1L));
         when(memberService.joinOauthMember(any())).thenReturn(1L);
         when(authService.issueAccessToken(anyLong())).thenReturn(new AccessToken("accessToken"));
         when(authService.issueRefreshToken(anyLong())).thenReturn(new RefreshToken(Member.builder().build(), "refreshToken"));
@@ -249,14 +230,15 @@ class AuthControllerTest {
 
         //when
         mockMvc.perform(
-                        post("/auth/jpa/apple/signin")
+                        post("/auth/jpa/apple/token")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(new ObjectMapper().writeValueAsString(appleSigninRequest)))
                 .andExpect(status().isOk())
+                .andDo(print())
                 .andExpect(jsonPath("$.code").value("1000"))
                 .andExpect(jsonPath("$.result.isNewUser").value(false));
     }
-
+    
     public Member createMemberWithId(Long id) throws NoSuchFieldException, IllegalAccessException {
         Member member = Member.builder().build();
         Field idField = member.getClass().getDeclaredField("id");

--- a/src/test/java/com/todoary/ms/src/web/controller/AuthControllerTest.java
+++ b/src/test/java/com/todoary/ms/src/web/controller/AuthControllerTest.java
@@ -2,6 +2,7 @@ package com.todoary.ms.src.web.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.todoary.ms.src.common.exception.TodoaryException;
+import com.todoary.ms.src.common.response.BaseResponseStatus;
 import com.todoary.ms.src.domain.Member;
 import com.todoary.ms.src.domain.ProviderAccount;
 import com.todoary.ms.src.domain.token.AccessToken;
@@ -9,10 +10,12 @@ import com.todoary.ms.src.domain.token.RefreshToken;
 import com.todoary.ms.src.service.AppleAuthService;
 import com.todoary.ms.src.service.JpaAuthService;
 import com.todoary.ms.src.service.MemberService;
+import com.todoary.ms.src.web.dto.AppleRevokeRequest;
 import com.todoary.ms.src.web.dto.AppleSigninRequest;
 import com.todoary.ms.src.web.dto.AppleSigninResponse;
 import com.todoary.ms.src.web.dto.MemberJoinParam;
 import net.minidev.json.JSONObject;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -20,6 +23,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +32,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.todoary.ms.src.common.response.BaseResponseStatus.MEMBERS_DUPLICATE_EMAIL;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -237,6 +242,30 @@ class AuthControllerTest {
                 .andDo(print())
                 .andExpect(jsonPath("$.code").value("1000"))
                 .andExpect(jsonPath("$.result.isNewUser").value(false));
+    }
+
+    @Test
+    public void 애플_회원_탈퇴_테스트() throws Exception {
+        //given
+        AppleRevokeRequest appleRevokeRequest = new AppleRevokeRequest(
+                "code",
+                "email"
+        );
+
+        Map<String, String> tokenResponse = new HashMap<>();
+        tokenResponse.put("refresh_token", "appleRefreshToken");
+
+        when(appleAuthService.getTokenResponseByCode(anyString())).thenReturn(new JSONObject(tokenResponse));
+        when(memberService.findByProviderEmail(any(), any())).thenReturn(createMemberWithId(1L));
+
+        //when
+        mockMvc.perform(
+                        post("/auth/jpa/revoke/apple")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(new ObjectMapper().writeValueAsString(appleRevokeRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("1000"))
+                .andReturn();
     }
     
     public Member createMemberWithId(Long id) throws NoSuchFieldException, IllegalAccessException {


### PR DESCRIPTION
## What is this PR? 🔍
- 애플 회원 탈퇴 기능 구현 완료했습니다.

## Changes 📝
- `findByProvider`의 경우에 email과 providerAccount로 멤버를 찾고 있는데, 
providerAccount 내부에는 provider와 providerId가 있기에 email은 굳이 필요 없어서 -> `findByProviderAccount`로 변경했습니다.

- `findByEmailOfGeneralMember`는 맥락상 `findGeneralMemberByEmail`로 rename하였습니다. 

## Test Checklist ☑️
- [X] 애플_회원_탈퇴_테스트()

## To Reviewers 📢
@Todoary/todoary_serverdeveloper 
- 투두 알림, 데일리 알람 구현해서 PR 올리겠습니다!
- AWS 계정 오늘 중으로 파는게 좋을 것 같은데, 어느 계정으로 팔지 얘기해볼 필요가 있는 것 같아요

