### PR TITLE
fix: todo 알람 설정 메소드에 Transactional 추가한다

### DIFF
--- a/src/main/java/com/todoary/ms/src/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/todoary/ms/src/common/response/BaseResponseStatus.java
@@ -43,6 +43,7 @@ public enum BaseResponseStatus {
     NULL_ARGUMENT(false, 2015, "입력값이 있어야 합니다."),
     MEMBERS_DUPLICATE_NICKNAME(false, 2016, "중복된 닉네임입니다."),
     MEMBERS_DUPLICATE_EMAIL(false, 2017, "중복된 이메일입니다."),
+    MEMBERS_EMPTY_FCM_TOKEN(false, 2018, "FCM 토큰값이 비어있습니다."),
 
     USERS_DISACCORD_PASSWORD(false, 2112, "비밀번호가 일치하지 않습니다"),
     USERS_REFRESH_TOKEN_NOT_EXISTS(false, 2113, "유저 정보와 일치하는 Refresh Token이 없습니다."),

--- a/src/main/java/com/todoary/ms/src/service/MemberService.java
+++ b/src/main/java/com/todoary/ms/src/service/MemberService.java
@@ -168,6 +168,7 @@ public class MemberService {
         return MemberResponse.from(findById(memberId));
     }
 
+    @Transactional
     public void activeTodoAlarm(Long memberId, boolean toDoAlarmEnable) {
         Member member = findById(memberId);
         member.activeTodoAlarm(toDoAlarmEnable);

--- a/src/main/java/com/todoary/ms/src/web/controller/MemberController.java
+++ b/src/main/java/com/todoary/ms/src/web/controller/MemberController.java
@@ -2,20 +2,22 @@ package com.todoary.ms.src.web.controller;
 
 
 import com.todoary.ms.src.common.auth.annotation.LoginMember;
+import com.todoary.ms.src.common.response.BaseResponse;
+import com.todoary.ms.src.common.response.BaseResponseStatus;
 import com.todoary.ms.src.domain.Member;
 import com.todoary.ms.src.s3.AwsS3Service;
 import com.todoary.ms.src.service.MemberService;
 import com.todoary.ms.src.web.dto.*;
-import com.todoary.ms.src.common.response.BaseResponse;
-import com.todoary.ms.src.common.response.BaseResponseStatus;
 import com.todoary.ms.src.web.dto.alarm.AlarmEnablesResponse;
 import com.todoary.ms.src.web.dto.alarm.DailyAlarmEnablesRequest;
 import com.todoary.ms.src.web.dto.alarm.RemindAlarmEnablesRequest;
 import com.todoary.ms.src.web.dto.alarm.TodoAlarmEnablesRequest;
-import lombok.*;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.Valid;
 
 import static com.todoary.ms.src.common.response.BaseResponseStatus.SUCCESS;
 
@@ -142,9 +144,9 @@ public class MemberController {
      * 2.10 FCM 토큰 갱신 api
      */
     @PatchMapping("/fcm_token")
-    public BaseResponse modifyFcmToken(
+    public BaseResponse<String> modifyFcmToken(
             @LoginMember Long memberId,
-            @RequestBody FcmTokenUpdateRequest request
+            @RequestBody @Valid FcmTokenUpdateRequest request
     ) {
         String fcmToken = request.getFcmToken();
         memberService.modifyFcmToken(memberId, fcmToken);

--- a/src/main/java/com/todoary/ms/src/web/dto/FcmTokenUpdateRequest.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/FcmTokenUpdateRequest.java
@@ -3,10 +3,15 @@ package com.todoary.ms.src.web.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.validation.constraints.NotNull;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class FcmTokenUpdateRequest {
+    @NotNull(message="MEMBERS_EMPTY_FCM_TOKEN")
     private String fcmToken;
 }

--- a/src/main/java/com/todoary/ms/src/web/dto/alarm/DailyAlarmEnablesRequest.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/alarm/DailyAlarmEnablesRequest.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class DailyAlarmEnablesRequest {
     @JsonProperty("isChecked")
     private boolean isChecked;

--- a/src/main/java/com/todoary/ms/src/web/dto/alarm/RemindAlarmEnablesRequest.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/alarm/RemindAlarmEnablesRequest.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class RemindAlarmEnablesRequest {
     @JsonProperty("isChecked")
     private boolean isChecked;

--- a/src/main/java/com/todoary/ms/src/web/dto/alarm/TodoAlarmEnablesRequest.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/alarm/TodoAlarmEnablesRequest.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class TodoAlarmEnablesRequest {
     @JsonProperty("isChecked")
     private boolean isChecked;


### PR DESCRIPTION
## What is this PR? 🔍
- fix: todo 알람 설정 메소드에 Transactional 추가한다
- fix: FCM 토큰 값 비어있을 때 에러 메시지 응답한다

## Changes 📝
@60jong @juwonleee 
- 서비스에서 todo 알람 바꾸는 쪽에만 Transactional 어노테이션이 없어서 값이 제대로 안바뀌고 있었습니다. 경종님이 하셨던거처럼 Transactional 필요 없는 건 private 메소드로 바꾸고 클래스에 어노테이션 바꾸는것도 괜찮을 것 같아요
- FCM 토큰 값 비어있을 때 에러 메시지 응답하도록 했습니다. 컨트롤러단 dto null이나 empty 검사 할 수 있으면 추가해주세요~ ENUM으로 메시지 지정해놓고 검사할 수 있도록 해놨으니까 참고하시면 편하실거에요~ 아니면 `TodoController`나 `CategoryController`쪽에 다 처리해놔서 그쪽 참고하셔도 됩니다!
  - 참고: #190  
