### PR TITLE
fix: Diary content 타입 TEXT로 변경한다

### DIFF
--- a/src/main/java/com/todoary/ms/src/domain/Diary.java
+++ b/src/main/java/com/todoary/ms/src/domain/Diary.java
@@ -25,6 +25,7 @@ public class Diary extends BaseTimeEntity{
 
     private String title;
 
+    @Column(columnDefinition = "TEXT")
     private String content;
 
     private LocalDate createdDate;


### PR DESCRIPTION
## What is this PR? 🔍
- 다이어리 content는 html 기반으로 되어있으므로 TEXT로 변경해 글자수 제한을 늘렸습니다.

## To Reviewers 📢
- 다른 엔티티 길이 제한도 확인 필요할 듯 싶습니다~
