### PR TITLE
fix: 로그인 시 존재하지 않는 이메일인지 먼저 검사하여 명세서와 같게 응답한다

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -24,5 +24,5 @@ hooks:
 
   ValidateService:
     - location: health.sh # 새 스프링 부트가 정상적으로 실행됐는지 확인 후 switch
-      timeout: 60
+      timeout: 120
       runas: ubuntu

--- a/service-scripts/profile.sh
+++ b/service-scripts/profile.sh
@@ -1,4 +1,4 @@
-#!/user/bin/env bash
+#!/usr/bin/env bash
 
 # bash는 return value가 안되니 *제일 마지막줄에 echo로 결과 출력*후, 클라이언트에서 값 사용
 
@@ -29,10 +29,22 @@ find_idle_port()
 {
   IDLE_PROFILE=$(find_idle_profile)
 
-  if [ ${IDLE_PROFILE} == release1 ]
+  if [ "${IDLE_PROFILE}" == release1 ]
   then
     echo "9001"
   else
     echo "9002"
   fi
+}
+
+find_not_idle_port()
+{
+    IDLE_PROFILE=$(find_idle_profile)
+
+    if [ "${IDLE_PROFILE}" == release1 ]
+    then
+      echo "9002"
+    else
+      echo "9001"
+    fi
 }

--- a/service-scripts/stop.sh
+++ b/service-scripts/stop.sh
@@ -4,13 +4,16 @@ ABSPATH=$(readlink -f $0)
 ABSDIR=$(dirname $ABSPATH)
 source ${ABSDIR}/profile.sh
 
-IDLE_PORT=$(find_idle_port)
+if [ $# -ge 1 ]; then
+  IDLE_PORT=$1
+else
+  IDLE_PORT=$(find_idle_port)
+fi
 
 echo "> $IDLE_PORT 에서 구동 중인 애플리케이션 pid 확인"
 IDLE_PID=$(lsof -ti tcp:"$IDLE_PORT")
 
-if [ -z ${IDLE_PID} ]
-then
+if [ -z ${IDLE_PID} ]; then
   echo "> 현재 구동 중인 애플리케이션이 없으므로 종료하지 않습니다."
 else
   echo "> kill -15 $IDLE_PID"

--- a/service-scripts/switch.sh
+++ b/service-scripts/switch.sh
@@ -3,6 +3,7 @@
 ABSPATH=$(readlink -f $0)
 ABSDIR=$(dirname $ABSPATH)
 source ${ABSDIR}/profile.sh
+source ${ABSDIR}/stop.sh
 
 switch_proxy()
 {
@@ -14,4 +15,6 @@ switch_proxy()
 
   echo "> 엔진엑스 Reload"
   sudo service nginx reload
+  # 다른 포트의 jar 종료
+  stop "$(find_not_idle_port)"
 }

--- a/src/main/java/com/todoary/ms/TodoaryApplication.java
+++ b/src/main/java/com/todoary/ms/TodoaryApplication.java
@@ -3,14 +3,12 @@ package com.todoary.ms;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.annotation.PostConstruct;
 import java.util.TimeZone;
 
-@EnableScheduling
 @SpringBootApplication
 public class TodoaryApplication {
 

--- a/src/main/java/com/todoary/ms/src/common/auth/PrincipalDetails.java
+++ b/src/main/java/com/todoary/ms/src/common/auth/PrincipalDetails.java
@@ -1,4 +1,4 @@
-package com.todoary.ms.src.legacy.auth.model;
+package com.todoary.ms.src.common.auth;
 
 import com.todoary.ms.src.domain.Member;
 import lombok.Getter;
@@ -11,18 +11,18 @@ import java.util.Collection;
 import java.util.Map;
 
 @Getter
-public class LegacyPrincipalDetails implements UserDetails, OAuth2User {
+public class PrincipalDetails implements UserDetails, OAuth2User {
 
     private Member member;
     private Map<String, Object> attributes;
     // 새로 가입시킨 멤버인가
     boolean isNewMember = false;
 
-    public LegacyPrincipalDetails(Member member) {
+    public PrincipalDetails(Member member) {
         this.member = member;
     }
 
-    public LegacyPrincipalDetails(Member member, Map<String, Object> attributes, boolean isNewMember) {
+    public PrincipalDetails(Member member, Map<String, Object> attributes, boolean isNewMember) {
         this.member = member;
         this.attributes = attributes;
         this.isNewMember = isNewMember;

--- a/src/main/java/com/todoary/ms/src/common/auth/PrincipalDetailsService.java
+++ b/src/main/java/com/todoary/ms/src/common/auth/PrincipalDetailsService.java
@@ -1,6 +1,5 @@
 package com.todoary.ms.src.common.auth;
 
-import com.todoary.ms.src.legacy.auth.model.LegacyPrincipalDetails;
 import com.todoary.ms.src.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -16,6 +15,6 @@ public class PrincipalDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        return new LegacyPrincipalDetails(memberService.findGeneralMemberByEmail(email));
+        return new PrincipalDetails(memberService.findGeneralMemberByEmail(email));
     }
 }

--- a/src/main/java/com/todoary/ms/src/common/auth/PrincipalOAuth2UserService.java
+++ b/src/main/java/com/todoary/ms/src/common/auth/PrincipalOAuth2UserService.java
@@ -2,7 +2,6 @@ package com.todoary.ms.src.common.auth;
 
 import com.todoary.ms.src.domain.Member;
 import com.todoary.ms.src.domain.ProviderAccount;
-import com.todoary.ms.src.legacy.auth.model.LegacyPrincipalDetails;
 import com.todoary.ms.src.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,10 +41,10 @@ public class PrincipalOAuth2UserService extends DefaultOAuth2UserService {
                         .providerAccount(providerAccount)
                         .build();
 
-            return new LegacyPrincipalDetails(member, oAuth2User.getAttributes(), true);
+            return new PrincipalDetails(member, oAuth2User.getAttributes(), true);
         } else {
             System.out.println("구글 로그인 기록이 있습니다. 로그인을 진행합니다.");
-            return new LegacyPrincipalDetails(member, oAuth2User.getAttributes(), false);
+            return new PrincipalDetails(member, oAuth2User.getAttributes(), false);
         }
     }
 

--- a/src/main/java/com/todoary/ms/src/common/auth/jwt/config/OAuth2SuccessHandler.java
+++ b/src/main/java/com/todoary/ms/src/common/auth/jwt/config/OAuth2SuccessHandler.java
@@ -5,7 +5,7 @@ import com.todoary.ms.src.legacy.auth.LegacyAuthService;
 import com.todoary.ms.src.legacy.auth.dto.GetOauth2SuccessRes;
 import com.todoary.ms.src.legacy.auth.dto.GetOauth2UserRes;
 import com.todoary.ms.src.common.auth.jwt.JwtTokenProvider;
-import com.todoary.ms.src.legacy.auth.model.LegacyPrincipalDetails;
+import com.todoary.ms.src.common.auth.PrincipalDetails;
 import com.todoary.ms.src.legacy.auth.dto.Token;
 import com.todoary.ms.src.common.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +32,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         response.setContentType("application/json");
         response.setCharacterEncoding("utf-8");
         
-        LegacyPrincipalDetails oAuth2User = (LegacyPrincipalDetails) authentication.getPrincipal();
+        PrincipalDetails oAuth2User = (PrincipalDetails) authentication.getPrincipal();
 
         GetOauth2SuccessRes getOauth2SuccessRes;
         if (oAuth2User.isNewMember()) { // 새로 가입한 유저

--- a/src/main/java/com/todoary/ms/src/common/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/todoary/ms/src/common/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -3,7 +3,7 @@ package com.todoary.ms.src.common.auth.jwt.filter;
 import com.todoary.ms.src.legacy.auth.LegacyAuthService;
 import com.todoary.ms.src.legacy.auth.dto.PostSigninRes;
 import com.todoary.ms.src.common.auth.jwt.JwtTokenProvider;
-import com.todoary.ms.src.legacy.auth.model.LegacyPrincipalDetails;
+import com.todoary.ms.src.common.auth.PrincipalDetails;
 import com.todoary.ms.src.legacy.auth.dto.Token;
 import com.todoary.ms.src.legacy.user.model.User;
 import com.todoary.ms.src.common.response.BaseResponse;
@@ -46,7 +46,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
                         // 여기서 PrincipalDetailsService의 loadByUsername 실행됨
             authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
             // ^ 갔다와서 실행됨
-            LegacyPrincipalDetails legacyPrincipalDetails = (LegacyPrincipalDetails) authentication.getPrincipal();
+            PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
 
 
         } catch (IOException e) {
@@ -57,9 +57,9 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
     @Override
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
-        LegacyPrincipalDetails legacyPrincipalDetails = (LegacyPrincipalDetails) authResult.getPrincipal();
+        PrincipalDetails principalDetails = (PrincipalDetails) authResult.getPrincipal();
 
-        Long userid = legacyPrincipalDetails.getMember().getId();
+        Long userid = principalDetails.getMember().getId();
         String accessToken = jwtTokenProvider.createAccessToken(userid);
         String refreshToken = jwtTokenProvider.createRefreshToken(userid);
 

--- a/src/main/java/com/todoary/ms/src/config/SchedulingConfig.java
+++ b/src/main/java/com/todoary/ms/src/config/SchedulingConfig.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
-@Profile({"release"})
+@Profile({"release1, release2"})
 @EnableScheduling
 public class SchedulingConfig {
 }

--- a/src/main/java/com/todoary/ms/src/repository/MemberRepository.java
+++ b/src/main/java/com/todoary/ms/src/repository/MemberRepository.java
@@ -119,7 +119,7 @@ public class MemberRepository {
     }
 
     public Optional<Member> findGeneralMemberByEmail(String email) {
-        return em.createQuery("select m from Member m where m.providerAccount = :providerAccount and m.email = :email")
+        return em.createQuery("select m from Member m where m.providerAccount = :providerAccount and m.email = :email", Member.class)
                 .setParameter("providerAccount", ProviderAccount.none())
                 .setParameter("email", email)
                 .getResultStream()
@@ -127,7 +127,7 @@ public class MemberRepository {
     }
 
     public List<Member> findAllForRemindAlarm(LocalDate targetDate) {
-        return em.createQuery("select m from Member m where m.remindAlarm.targetDate = :targetDate and m.remindAlarmEnable = true")
+        return em.createQuery("select m from Member m where m.remindAlarm.targetDate = :targetDate and m.remindAlarmEnable = true", Member.class)
                 .setParameter("targetDate", targetDate)
                 .getResultList();
     }

--- a/src/main/java/com/todoary/ms/src/repository/TodoRepository.java
+++ b/src/main/java/com/todoary/ms/src/repository/TodoRepository.java
@@ -89,7 +89,7 @@ public class TodoRepository {
     }
 
     public List<Todo> findAllByDate(LocalDate targetDate) {
-        return em.createQuery("select t from Todo t where t.targetDate = :targetDate")
+        return em.createQuery("select t from Todo t where t.targetDate = :targetDate", Todo.class)
                 .setParameter("targetDate", targetDate)
                 .getResultList();
     }

--- a/src/main/java/com/todoary/ms/src/service/AuthService.java
+++ b/src/main/java/com/todoary/ms/src/service/AuthService.java
@@ -1,7 +1,7 @@
 package com.todoary.ms.src.service;
 
 import com.todoary.ms.src.common.auth.jwt.JwtTokenProvider;
-import com.todoary.ms.src.legacy.auth.model.LegacyPrincipalDetails;
+import com.todoary.ms.src.common.auth.PrincipalDetails;
 import com.todoary.ms.src.domain.Member;
 import com.todoary.ms.src.domain.token.AccessToken;
 import com.todoary.ms.src.domain.token.RefreshToken;
@@ -40,7 +40,6 @@ public class AuthService {
         return memberId == Long.parseLong(jwtTokenProvider.getUserIdFromAccessToken(accessTokenCode));
     }
 
-    @Transactional
     public RefreshToken createRefreshToken(Member member) {
         String code = jwtTokenProvider.createRefreshToken(member.getId());
         if (member.hasRefreshToken()) {
@@ -56,8 +55,9 @@ public class AuthService {
         try {
             UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(email, password);
 
+            //PrincipalDetailsService::loadUserByUsername
             Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-            return ((LegacyPrincipalDetails) authentication.getPrincipal())
+            return ((PrincipalDetails) authentication.getPrincipal())
                     .getMember()
                     .getId();
         } catch (BadCredentialsException badCredentialsException) {


### PR DESCRIPTION
## What is this PR? 🔍
- FCM 토큰 코드가 비어있지 않을 때만 알림 보내도록 수정했습니다
- 로그인 시 존재하지 않는 이메일인지 먼저 검사하여 명세서와 같게 응답하도록 했습니다.

## Test Checklist ☑️
- [X] 일반 로그인 성공 테스트시 가입한 이메일 있다고 응답하도록 스텁 설정
- [X] 자동 로그인 성공 테스트시 가입한 이메일 있다고 응답하도록 스텁 설정
- [X] 가입한 이메일 있을 때 일반 로그인 실패하고 명세서 코드대로 응답하는 지 테스트

## To Reviewers 📢
@60jong 로그인시에 authenticate 함수로 LegacyPrincipalDetails 이용하는 것 같은데 클래스가 Legacy로 되어 있어서 수정했습니다. 확인해주세요~



