### PR TITLE
test : Auth, 비밀번호가 틀린 경우 예외 코드 테스트 케이스 추가

### DIFF
--- a/.github/workflows/develop-deploy.yml
+++ b/.github/workflows/develop-deploy.yml
@@ -64,7 +64,7 @@ jobs:
             git fetch --all || exit 1
             git reset --hard origin/Develop || exit 1
             git pull origin Develop || exit 1
-            git submodule update --remote --merge || exit 1
+            git submodule update --remote --hard || exit 1
 
             ./scripts/build.sh || exit 1
             ./scripts/stop.sh || exit 1

--- a/src/main/java/com/todoary/ms/src/service/AuthService.java
+++ b/src/main/java/com/todoary/ms/src/service/AuthService.java
@@ -56,7 +56,7 @@ public class AuthService {
             UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(email, password);
 
             //PrincipalDetailsService::loadUserByUsername
-            Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+            Authentication authentication = getAuthentication(authenticationToken);
             return ((PrincipalDetails) authentication.getPrincipal())
                     .getMember()
                     .getId();
@@ -66,6 +66,18 @@ public class AuthService {
         } catch (AuthenticationException authenticationException) {
             // authenticate 실패했을 때 예외 발생
             throw new TodoaryException(USERS_AUTHENTICATION_FAILURE);
+        }
+    }
+
+    // authService의 통제 밖인 authenticationManger(authenticationManagerBuilder.getObject())를 테스트하기 위해 메서드 분리
+    public Authentication getAuthentication(UsernamePasswordAuthenticationToken authenticationToken)
+            throws BadCredentialsException, AuthenticationException{
+        try {
+            return authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        } catch (BadCredentialsException badCredentialsException) {
+            throw badCredentialsException;
+        } catch (AuthenticationException authenticationException) {
+            throw authenticationException;
         }
     }
 


### PR DESCRIPTION
## What is this PR? 🔍
- member의 일반 로그인에서 비밀번호가 틀린 경우의 예외 코드 test case 추가했습니다.

## Changes 📝
- `authService.authenticate()`에서 `authenticationManagerBuilder.getObject().authenticate()`는 mocking이 힘들어, 
`authService.getAuthentication()`으로 분리 후에 예외를 던지도록했습니다. 이로 인해 mocking을 이용한 테스트가 가능해졌습니다.

## Test Checklist ☑️
- [X] 일반로그인시_비밀번호_틀릴때_에러코드_응답()

이외에도 급하게 구현하며 테스트 케이스 생략한 기능들 테케 추가하겠습니다.
