### PR TITLE
fix: 투두 없을 때 삭제 요청 시 api 명세서에 맞는 응답한다

### DIFF
--- a/src/main/java/com/todoary/ms/src/domain/Todo.java
+++ b/src/main/java/com/todoary/ms/src/domain/Todo.java
@@ -88,4 +88,8 @@ public class Todo extends BaseTimeEntity {
     public void pin(boolean isPinned){
         this.isPinned = isPinned;
     }
+
+    public boolean has(Member member) {
+        return this.member == member;
+    }
 }

--- a/src/main/java/com/todoary/ms/src/service/todo/TodoService.java
+++ b/src/main/java/com/todoary/ms/src/service/todo/TodoService.java
@@ -22,7 +22,7 @@ import java.time.YearMonth;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.todoary.ms.src.common.response.BaseResponseStatus.USERS_CATEGORY_NOT_EXISTS;
+import static com.todoary.ms.src.common.response.BaseResponseStatus.USERS_TODO_NOT_EXISTS;
 
 @RequiredArgsConstructor
 @Service
@@ -134,9 +134,9 @@ public class TodoService {
 
     private Todo findTodoByIdAndMember(Long todoId, Member member) {
         Todo todo = todoRepository.findById(todoId)
-                .orElseThrow(() -> new TodoaryException(USERS_CATEGORY_NOT_EXISTS));
-        if (!todo.getMember().equals(member))
-            throw new TodoaryException(USERS_CATEGORY_NOT_EXISTS);
+                .orElseThrow(() -> new TodoaryException(USERS_TODO_NOT_EXISTS));
+        if (!todo.has(member))
+            throw new TodoaryException(USERS_TODO_NOT_EXISTS);
         return todo;
     }
 

--- a/src/test/java/com/todoary/ms/src/web/controller/TodoControllerTest.java
+++ b/src/test/java/com/todoary/ms/src/web/controller/TodoControllerTest.java
@@ -1,6 +1,7 @@
 package com.todoary.ms.src.web.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todoary.ms.src.common.exception.TodoaryException;
 import com.todoary.ms.src.common.response.BaseResponseStatus;
 import com.todoary.ms.src.config.auth.WithTodoaryMockUser;
 import com.todoary.ms.src.service.todo.TodoService;
@@ -36,7 +37,7 @@ import static com.todoary.ms.src.web.controller.TestUtils.*;
 import static com.todoary.ms.src.web.controller.TodoControllerTest.REQUEST_URL.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -295,7 +296,9 @@ class TodoControllerTest {
     @WithTodoaryMockUser
     void 투두_삭제O() throws Exception {
         // given
-
+        willDoNothing()
+                .given(todoService)
+                .deleteTodo(any(), any());
         // when
         MvcResult result = mvc.perform(delete(REQUEST_URL.DELETE, 1L).with(csrf()))
                 .andExpect(status().isOk())
@@ -304,6 +307,23 @@ class TodoControllerTest {
         BaseResponseStatus status = getResponseObject(result);
         // then
         assertThat(status).isEqualTo(SUCCESS);
+    }
+
+    @Test
+    @WithTodoaryMockUser
+    void 투두_없을때_삭제X() throws Exception {
+        // given
+        willThrow(new TodoaryException(USERS_TODO_NOT_EXISTS))
+                .given(todoService)
+                .deleteTodo(any(), any());
+        // when
+        MvcResult result = mvc.perform(delete(REQUEST_URL.DELETE, 1L).with(csrf()))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn();
+        BaseResponseStatus status = getResponseObject(result);
+        // then
+        assertThat(status).isEqualTo(USERS_TODO_NOT_EXISTS);
     }
 
     @Test


### PR DESCRIPTION
## What is this PR? 🔍
- 투두 없을 때 삭제 요청 시 투두가 아니라 카테고리가 없다고 메시지 잘못 응답하고 있어서 수정했습니다.

## Test Checklist ☑️
todo controller 테스트시에 스텁을 제대로 안하고 있어서 일단 삭제 상황에서는 추가해뒀고 빠른 시일 내에 추가하겠습니다!
- [X] 투두 있을 때 삭제 성공
- [X] 투두 없을 때 삭제 실패
