### PR TITLE
Member 프로필 사진 초기화 API 구현 & AWS 계정 통합 설정

### DIFF
--- a/src/main/java/com/todoary/ms/src/web/controller/MemberController.java
+++ b/src/main/java/com/todoary/ms/src/web/controller/MemberController.java
@@ -13,6 +13,7 @@ import com.todoary.ms.src.web.dto.alarm.DailyAlarmEnablesRequest;
 import com.todoary.ms.src.web.dto.alarm.RemindAlarmEnablesRequest;
 import com.todoary.ms.src.web.dto.alarm.TodoAlarmEnablesRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -57,11 +58,15 @@ public class MemberController {
     }
 
     // 2.3 프로필 사진 삭제 api
+    @PatchMapping("/profile-img/default")
+    public BaseResponse<String> resetProfileImg(@LoginMember Long memberId) {
+        if (memberService.checkProfileImgIsDefault(memberId)) {
+            return new BaseResponse<>("삭제에 성공했습니다.");
+        }
 
-    /**
-     * API 2.3은 멤버 회원 탈퇴 시에 AWS S3에 저장된 프로필 사진을 삭제하기 위함.
-     * 따라서 별도의 API 대신 memberService에 로직 추가하는 것으로 대체.
-     */
+        memberService.setProfileImgDefault(memberId);
+        return new BaseResponse<>("삭제에 성공했습니다.");
+    }
 
     // 2.4 프로필 조회 api
     @GetMapping("")

--- a/src/test/java/com/todoary/ms/src/web/controller/MemberControllerTest.java
+++ b/src/test/java/com/todoary/ms/src/web/controller/MemberControllerTest.java
@@ -24,9 +24,9 @@ import java.io.IOException;
 import static com.todoary.ms.src.web.controller.TestUtils.getResponseObject;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Transactional
@@ -135,6 +135,27 @@ class MemberControllerTest {
 
         //then
         assertThat(getResponseObject(result)).isEqualTo(BaseResponseStatus.SUCCESS);
+    }
+
+    @Test
+    @WithTodoaryMockUser
+    public void 기본_프로필일때_프로필_사진_초기화_테스트() throws Exception {
+        when(memberService.checkProfileImgIsDefault(any())).thenReturn(true);
+
+        mockMvc.perform(patch("/member/profile-img/default"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("1000"));
+    }
+
+    @Test
+    @WithTodoaryMockUser
+    public void 수정된_프로필일때_프로필_사진_초기화_테스트() throws Exception {
+        when(memberService.checkProfileImgIsDefault(any())).thenReturn(false);
+        doNothing().when(memberService).setProfileImgDefault(anyLong());
+
+        mockMvc.perform(patch("/member/profile-img/default"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("1000"));
     }
 
     String createTestImage(String fileName, String contentType, String directory) throws IOException {


### PR DESCRIPTION
## What is this PR? 🔍
- `MemberController` 멤버 프로필 사진 초기화 기능 구현
- `yml` aws 계정 통합에 따른 `rds`, `s3` 설정을 dev와 local에서도 접근이 가능하도록 수정했습니다.

## Changes 📝
- `application.yml`의 `profile-image.path` 프로퍼티를 각 개발 환경에 맞게 세팅했습니다.
  - release : `todoary/`
  - dev : `develop/`
  - test & local : `test/`

## Test Checklist ☑️
- [X] 프로필_사진_초기화테스트_수정된_프로필사진일때
- [X] 프로필_사진_초기화테스트_기본_프로필사진일때
- [X] 프로필사진이_default가_아닐때_check()
- [X] 프로필사진이_default일때_check()
- [X] 기본_프로필일때_프로필_사진_초기화_테스트()
- [X] 수정된_프로필일때_프로필_사진_초기화_테스트()
