### PR TITLE
feat: 탈퇴 30일 후 삭제하며, 삭제 전에 복구할 수 있도록 api 추가한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,8 +112,9 @@ task copyTestResources {
     doLast {
         println '*********** test copy start ***********'
         copy {
-            from './config/application-local-h2.yml', './config/application.yml'
+            from './config/application-test.yml'
             into './src/test/resources'
+            rename 'application-test.yml', 'application.yml'
         }
         println '*********** test copy end *************'
     }

--- a/src/main/java/com/todoary/ms/src/common/aspect/LoggingAspectHandler.java
+++ b/src/main/java/com/todoary/ms/src/common/aspect/LoggingAspectHandler.java
@@ -10,6 +10,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 @Component
 @Aspect
 public class LoggingAspectHandler {
@@ -25,14 +28,14 @@ public class LoggingAspectHandler {
     @AfterReturning(value = "allControllers() || allInNotificationService()", returning = "result")
     public void doReturnLogging(JoinPoint joinPoint, Object result) {
         if (result instanceof BaseResponse) {
-            log.info("[Return] {} request={} return={}", joinPoint.getSignature().toShortString(), joinPoint.getArgs(), ((BaseResponse<?>) result).getResult());
+            log.info("[Return] {} | request={} | return={}", joinPoint.getSignature().toShortString(), joinPoint.getArgs(), ((BaseResponse<?>) result).getResult());
         } else {
-            log.info("[Return] {} request={} return={}", joinPoint.getSignature().toShortString(), joinPoint.getArgs(), result);
+            log.info("[Return] {} | request={} | return={}", joinPoint.getSignature().toShortString(), joinPoint.getArgs(), result);
         }
     }
 
     @AfterThrowing(value = "allControllers() || allInNotificationService()", throwing = "exception")
     public void doExceptionLogging(JoinPoint joinPoint, Exception exception) {
-        log.error("[Exception] {} request={} message={}", joinPoint.getSignature().toShortString(), joinPoint.getArgs(), exception.getMessage());
+        log.error("[Exception] {} | request={} | message={} | stacktrace={}", joinPoint.getSignature().toShortString(), joinPoint.getArgs(), exception.getMessage(), Arrays.stream(exception.getStackTrace()).limit(5).collect(Collectors.toList()));
     }
 }

--- a/src/main/java/com/todoary/ms/src/common/auth/PrincipalDetailsService.java
+++ b/src/main/java/com/todoary/ms/src/common/auth/PrincipalDetailsService.java
@@ -15,6 +15,6 @@ public class PrincipalDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        return new PrincipalDetails(memberService.findGeneralMemberByEmail(email));
+        return new PrincipalDetails(memberService.findActiveGeneralMemberByEmail(email));
     }
 }

--- a/src/main/java/com/todoary/ms/src/common/auth/PrincipalOAuth2UserService.java
+++ b/src/main/java/com/todoary/ms/src/common/auth/PrincipalOAuth2UserService.java
@@ -31,7 +31,7 @@ public class PrincipalOAuth2UserService extends DefaultOAuth2UserService {
         String provider_id = (String) oAuth2User.getAttributes().get("sub");
 
         ProviderAccount providerAccount = ProviderAccount.from(provider, provider_id);
-        Member member = memberService.findByEmailAndProviderAccount(email, providerAccount);
+        Member member = memberService.findActiveMemberByEmailAndProviderAccount(email, providerAccount);
 
         if (member == null) {
             System.out.println("구글 로그인 최초입니다. 회원가입을 진행합니다.");

--- a/src/main/java/com/todoary/ms/src/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/todoary/ms/src/common/response/BaseResponseStatus.java
@@ -35,12 +35,12 @@ public enum BaseResponseStatus {
     USERS_EMPTY_USER_ID(false, 2010, "유저 아이디 값을 확인해주세요."),
     USERS_EMPTY_USER_EMAIL(false, 2011, "유저 이메일 값을 확인해주세요."),
     USERS_DELETED_USER(false, 2012, "삭제된 유저입니다."),
-
     NULL_ARGUMENT(false, 2015, "입력값이 있어야 합니다."),
     MEMBERS_DUPLICATE_NICKNAME(false, 2032, "중복된 닉네임입니다."),
     MEMBERS_DUPLICATE_EMAIL(false, 2017, "중복된 이메일입니다."),
     MEMBERS_EMPTY_FCM_TOKEN(false, 2018, "FCM 토큰값이 비어있습니다."),
-
+    NOT_USED_EMAIL(true, 2019, "사용 가능한 이메일입니다."),
+    EMAIL_USED_BY_DEACTIVATED_MEMBER(false, 2020, "탈퇴한 멤버의 이메일입니다."),
     USERS_DISACCORD_PASSWORD(false, 2112, "비밀번호가 일치하지 않습니다"),
     USERS_REFRESH_TOKEN_NOT_EXISTS(false, 2113, "유저 정보와 일치하는 Refresh Token이 없습니다."),
     USERS_AUTHENTICATION_FAILURE(false, 2114, "유저 인증을 실패했습니다."),

--- a/src/main/java/com/todoary/ms/src/domain/Member.java
+++ b/src/main/java/com/todoary/ms/src/domain/Member.java
@@ -8,11 +8,13 @@ import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
+@ToString(exclude = {"todos", "categories", "diaries"})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor @Builder
-@EqualsAndHashCode(of = {"email", "providerAccount"}, callSuper = false)
+@AllArgsConstructor
+@Builder
 @Entity
 public class Member extends BaseTimeEntity {
     @Id
@@ -198,5 +200,27 @@ public class Member extends BaseTimeEntity {
     public FcmToken updateFcmToken(String code) {
         this.fcmToken.changeCode(code);
         return this.fcmToken;
+    }
+
+    @Override
+    public int hashCode() {
+        if (this.providerAccount.isGeneral()) {
+            return Objects.hash(email, this.providerAccount);
+        } else {
+            return Objects.hash(this.providerAccount);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Member)) return false;
+        Member member = (Member) o;
+        if (this.providerAccount.getProvider() != member.providerAccount.getProvider()) return false;
+        if (this.providerAccount.isGeneral()) {
+            return this.email.equals(member.getEmail());
+        } else {
+            return this.providerAccount.equals(member.getProviderAccount());
+        }
     }
 }

--- a/src/main/java/com/todoary/ms/src/domain/Member.java
+++ b/src/main/java/com/todoary/ms/src/domain/Member.java
@@ -56,7 +56,7 @@ public class Member extends BaseTimeEntity {
     @Builder.Default
     private List<Category> categories = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<Diary> diaries = new ArrayList<>();
 
@@ -172,8 +172,12 @@ public class Member extends BaseTimeEntity {
         this.introduce = introduce;
     }
 
-    public boolean isDeleted() {
+    public boolean isDeactivated() {
         return status == 0;
+    }
+
+    public void activate() {
+        this.status = 1;
     }
 
     public void deactivate() {

--- a/src/main/java/com/todoary/ms/src/domain/ProviderAccount.java
+++ b/src/main/java/com/todoary/ms/src/domain/ProviderAccount.java
@@ -43,4 +43,13 @@ public class ProviderAccount {
     public static ProviderAccount from(String provider, String provider_id) {
         return new ProviderAccount(Provider.findByProviderName(provider), provider_id);
     }
+
+    public static ProviderAccount of(String provider, String providerId) {
+        if (provider.equals("apple")) {
+            return appleFrom(providerId);
+        } else if (provider.equals("google")) {
+            return googleFrom(providerId);
+        }
+        return ProviderAccount.none();
+    }
 }

--- a/src/main/java/com/todoary/ms/src/domain/ProviderAccount.java
+++ b/src/main/java/com/todoary/ms/src/domain/ProviderAccount.java
@@ -3,6 +3,7 @@ package com.todoary.ms.src.domain;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
@@ -11,6 +12,7 @@ import javax.validation.constraints.NotNull;
 
 import static com.todoary.ms.src.domain.Provider.APPLE;
 
+@ToString
 @Getter
 @NoArgsConstructor
 @EqualsAndHashCode(of = {"provider", "providerId"})
@@ -45,11 +47,15 @@ public class ProviderAccount {
     }
 
     public static ProviderAccount of(String provider, String providerId) {
-        if (provider.equals("apple")) {
+        if (provider.equalsIgnoreCase("apple")) {
             return appleFrom(providerId);
-        } else if (provider.equals("google")) {
+        } else if (provider.equalsIgnoreCase("google")) {
             return googleFrom(providerId);
         }
         return ProviderAccount.none();
+    }
+
+    public boolean isGeneral() {
+        return this.provider.equals(Provider.NONE);
     }
 }

--- a/src/main/java/com/todoary/ms/src/repository/MemberRepository.java
+++ b/src/main/java/com/todoary/ms/src/repository/MemberRepository.java
@@ -2,7 +2,6 @@ package com.todoary.ms.src.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.todoary.ms.src.domain.Member;
-import com.todoary.ms.src.domain.Provider;
 import com.todoary.ms.src.domain.ProviderAccount;
 import com.todoary.ms.src.domain.token.RefreshToken;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -95,13 +94,6 @@ public class MemberRepository {
 
     public Optional<Member> findByEmail(String email) {
         return em.createQuery("select m from Member m where m.email = :email and m.status = 1", Member.class)
-                .setParameter("email", email)
-                .getResultStream().findAny();
-    }
-
-    public Optional<Member> findByProviderEmail(Provider provider, String email) {
-        return em.createQuery("select m from Member m where m.providerAccount.provider = :provider and m.email = :email", Member.class)
-                .setParameter("provider", provider)
                 .setParameter("email", email)
                 .getResultStream().findAny();
     }

--- a/src/main/java/com/todoary/ms/src/repository/MemberRepository.java
+++ b/src/main/java/com/todoary/ms/src/repository/MemberRepository.java
@@ -136,7 +136,7 @@ public class MemberRepository {
         return em.createQuery("select m from Member m " +
                 "where m.email = :email " +
                 "and m.providerAccount.provider = :provider " +
-                "and m.providerAccount.providerId = :providerId")
+                "and m.providerAccount.providerId = :providerId", Member.class)
                 .setParameter("email", email)
                 .setParameter("provider", providerAccount.getProvider())
                 .setParameter("providerId", providerAccount.getProviderId())
@@ -144,7 +144,13 @@ public class MemberRepository {
                 .findAny();
     }
 
-    public void deleteMember(Member member) {
+    public void removeMember(Member member) {
         em.remove(member);
+    }
+
+    public List<Member> findMemberDeactivatedTimeBefore(LocalDateTime time) {
+        return em.createQuery("select m from Member m where m.status = 0 and m.modifiedAt < :time", Member.class)
+                .setParameter("time", time)
+                .getResultList();
     }
 }

--- a/src/main/java/com/todoary/ms/src/service/AppleAuthService.java
+++ b/src/main/java/com/todoary/ms/src/service/AppleAuthService.java
@@ -31,11 +31,9 @@ import java.security.PrivateKey;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 
 import static com.todoary.ms.src.common.response.BaseResponseStatus.*;
-import static com.todoary.ms.src.common.response.BaseResponseStatus.APPLE_AUTHENTICATION_CODE_VALIDATION_FAILURE;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -115,13 +113,15 @@ public class AppleAuthService {
 
         HttpEntity httpEntity = new HttpEntity(tokenRequest, httpHeaders);
         RestTemplate restTemplate = new RestTemplate();
-        ResponseEntity<Map> response = restTemplate.postForEntity(AUTH_TOKEN_URL, httpEntity, Map.class);
-
-        if (response.getStatusCode().equals(HttpStatus.BAD_REQUEST)) {
+        try {
+            ResponseEntity<Map> response = restTemplate.postForEntity(AUTH_TOKEN_URL, httpEntity, Map.class);
+            if (response.getStatusCode().equals(HttpStatus.BAD_REQUEST)) {
+                throw new TodoaryException(APPLE_AUTHENTICATION_CODE_VALIDATION_FAILURE);
+            }
+            return response.getBody();
+        } catch(Exception e) {
             throw new TodoaryException(APPLE_AUTHENTICATION_CODE_VALIDATION_FAILURE);
         }
-
-        return response.getBody();
     }
 
     private PrivateKey getPrivateKey() {

--- a/src/main/java/com/todoary/ms/src/service/ExpiredMemberHandlerService.java
+++ b/src/main/java/com/todoary/ms/src/service/ExpiredMemberHandlerService.java
@@ -1,0 +1,36 @@
+package com.todoary.ms.src.service;
+
+import com.todoary.ms.src.domain.Member;
+import com.todoary.ms.src.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ExpiredMemberHandlerService {
+    private final MemberRepository memberRepository;
+
+    @Scheduled(cron = "0 0 0 1/1 * ?")
+    public int deleteMembersElapsed30DaysAfterDeactivated() {
+        log.info("탈퇴한 지 한달 지난 멤버 삭제 확인 triggered");
+        LocalDateTime before30Days = LocalDateTime.now().minusDays(30);
+        return deleteMembersDeactivatedTimeBefore(before30Days);
+    }
+
+    @Transactional
+    public int deleteMembersDeactivatedTimeBefore(LocalDateTime time){
+        List<Member> membersShouldBeDeleted = memberRepository.findMemberDeactivatedTimeBefore(time);
+        if (!membersShouldBeDeleted.isEmpty()){
+            membersShouldBeDeleted.forEach(memberRepository::removeMember);
+            log.info("{}명의 탈퇴한 멤버 삭제됨", membersShouldBeDeleted.size());
+        }
+        return membersShouldBeDeleted.size();
+    }
+}

--- a/src/main/java/com/todoary/ms/src/service/MemberService.java
+++ b/src/main/java/com/todoary/ms/src/service/MemberService.java
@@ -4,7 +4,6 @@ import com.todoary.ms.src.common.auth.jwt.JwtTokenProvider;
 import com.todoary.ms.src.common.exception.TodoaryException;
 import com.todoary.ms.src.domain.Category;
 import com.todoary.ms.src.domain.Member;
-import com.todoary.ms.src.domain.Provider;
 import com.todoary.ms.src.domain.ProviderAccount;
 import com.todoary.ms.src.domain.token.FcmToken;
 import com.todoary.ms.src.repository.MemberRepository;
@@ -133,11 +132,6 @@ public class MemberService {
     @Transactional(readOnly = true)
     public Member findActiveGeneralMemberByEmail(String email) {
         return checkMemberValid(memberRepository.findGeneralMemberByEmail(email));
-    }
-
-    @Transactional(readOnly = true)
-    public Member findActiveMemberByProviderEmail(Provider provider, String email) {
-        return checkMemberValid(memberRepository.findByProviderEmail(provider, email));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/todoary/ms/src/service/alarm/FireBaseCloudMessageService.java
+++ b/src/main/java/com/todoary/ms/src/service/alarm/FireBaseCloudMessageService.java
@@ -146,7 +146,7 @@ public class FireBaseCloudMessageService {
     }
 
     private boolean canMemberReceiveAlarm(Member member, Predicate<Member> alarmEnabled) {
-        return !member.isDeleted() && member.getFcmToken() != null && isCodeValid(member.getFcmToken().getCode()) && alarmEnabled.test(member);
+        return !member.isDeactivated() && member.getFcmToken() != null && isCodeValid(member.getFcmToken().getCode()) && alarmEnabled.test(member);
     }
 
     private boolean isCodeValid(String code) {

--- a/src/main/java/com/todoary/ms/src/web/controller/AuthController.java
+++ b/src/main/java/com/todoary/ms/src/web/controller/AuthController.java
@@ -215,6 +215,10 @@ public class AuthController {
             memberDeactivated = member.get().isDeactivated();
             memberId = member.get().getId();
         }
+        Token token = null;
+        if (!memberDeactivated) {
+            token = new Token(authService.issueAccessToken(memberId).getCode(), authService.issueRefreshToken(memberId).getCode());
+        }
         return new BaseResponse<>(new AppleSigninResponse(
                 !memberExists,
                 memberDeactivated,
@@ -222,7 +226,7 @@ public class AuthController {
                 appleSigninRequest.getEmail(),
                 providerAccount.getProvider().name(),
                 providerAccount.getProviderId(),
-                new Token(authService.issueAccessToken(memberId).getCode(), authService.issueRefreshToken(memberId).getCode()),
+                token,
                 appleRefreshToken
         ));
     }

--- a/src/main/java/com/todoary/ms/src/web/controller/AuthController.java
+++ b/src/main/java/com/todoary/ms/src/web/controller/AuthController.java
@@ -4,7 +4,6 @@ import com.todoary.ms.src.common.exception.TodoaryException;
 import com.todoary.ms.src.common.response.BaseResponse;
 import com.todoary.ms.src.common.response.BaseResponseStatus;
 import com.todoary.ms.src.domain.Member;
-import com.todoary.ms.src.domain.Provider;
 import com.todoary.ms.src.domain.ProviderAccount;
 import com.todoary.ms.src.domain.token.AccessToken;
 import com.todoary.ms.src.domain.token.RefreshToken;
@@ -236,11 +235,11 @@ public class AuthController {
         // revoke from Apple
         JSONObject tokenResponse = appleAuthService.getTokenResponseByCode(appleRevokeRequest.getCode());
         String appleRefreshToken = tokenResponse.getAsString("refresh_token");
-
         appleAuthService.revoke(appleRefreshToken);
 
         // revoke from Todoary
-        Member member = memberService.findActiveMemberByProviderEmail(Provider.APPLE, appleRevokeRequest.getEmail());
+        String providerId = appleAuthService.getProviderIdFrom(tokenResponse.getAsString("id_token"));
+        Member member = memberService.findActiveMemberByProviderAccount(ProviderAccount.appleFrom(providerId));
         memberService.deactivateMember(member);
 
         return new BaseResponse<>(SUCCESS);

--- a/src/main/java/com/todoary/ms/src/web/controller/MemberController.java
+++ b/src/main/java/com/todoary/ms/src/web/controller/MemberController.java
@@ -13,7 +13,6 @@ import com.todoary.ms.src.web.dto.alarm.DailyAlarmEnablesRequest;
 import com.todoary.ms.src.web.dto.alarm.RemindAlarmEnablesRequest;
 import com.todoary.ms.src.web.dto.alarm.TodoAlarmEnablesRequest;
 import lombok.RequiredArgsConstructor;
-import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -80,7 +79,7 @@ public class MemberController {
     public BaseResponse<BaseResponseStatus> patchMemberStatus(
             @LoginMember Long memberId
     ) {
-        memberService.removeMember(memberId);
+        memberService.deactivateMember(memberId);
         return BaseResponse.from(SUCCESS);
     }
 

--- a/src/main/java/com/todoary/ms/src/web/dto/AppleRevokeRequest.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/AppleRevokeRequest.java
@@ -3,10 +3,12 @@ package com.todoary.ms.src.web.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class AppleRevokeRequest {
     private String email;
     private String code;

--- a/src/main/java/com/todoary/ms/src/web/dto/AppleSigninResponse.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/AppleSigninResponse.java
@@ -1,14 +1,13 @@
 package com.todoary.ms.src.web.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class AppleSigninResponse {
-    @JsonProperty("isNewUser")
-    private boolean isNewUser;
+    private Boolean isNewUser;
+    private Boolean isDeactivatedUser;
     private String name;
     private String email;
     private String provider;

--- a/src/main/java/com/todoary/ms/src/web/dto/AppleSigninResponse.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/AppleSigninResponse.java
@@ -2,7 +2,9 @@ package com.todoary.ms.src.web.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 
+@ToString
 @Getter
 @AllArgsConstructor
 public class AppleSigninResponse {

--- a/src/main/java/com/todoary/ms/src/web/dto/RestoreRequest.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/RestoreRequest.java
@@ -1,0 +1,18 @@
+package com.todoary.ms.src.web.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class RestoreRequest {
+    @NotNull(message="USERS_EMPTY_USER_EMAIL")
+    private String email;
+    private String provider;
+    private String providerId;
+}

--- a/src/test/java/com/todoary/ms/src/config/TestJpaAuditingConfig.java
+++ b/src/test/java/com/todoary/ms/src/config/TestJpaAuditingConfig.java
@@ -1,0 +1,18 @@
+package com.todoary.ms.src.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@TestConfiguration
+@EnableJpaAuditing(dateTimeProviderRef = "testDateTimeProvider")
+public class TestJpaAuditingConfig {
+    @Bean
+    public DateTimeProvider testDateTimeProvider() {
+        return () -> Optional.of(LocalDateTime.now());
+    }
+}

--- a/src/test/java/com/todoary/ms/src/service/ExpiredMemberHandlerServiceTest.java
+++ b/src/test/java/com/todoary/ms/src/service/ExpiredMemberHandlerServiceTest.java
@@ -1,0 +1,62 @@
+package com.todoary.ms.src.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.data.auditing.AuditingHandler;
+import org.springframework.data.auditing.DateTimeProvider;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static com.todoary.ms.src.service.MemberServiceTest.createMemberJoinParamOfEmail;
+import static com.todoary.ms.src.service.MemberServiceTest.createOauthMemberJoinParamOfEmail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+class ExpiredMemberHandlerServiceTest {
+
+    @Autowired
+    MemberService memberService;
+    @Autowired
+    ExpiredMemberHandlerService expiredMemberHandlerService;
+    @MockBean
+    DateTimeProvider dateTimeProvider;
+    @SpyBean
+    AuditingHandler handler;
+
+    @Test
+    void 탈퇴한지_30일지난_일반_멤버_삭제됨() {
+        // given
+        handler.setDateTimeProvider(dateTimeProvider);
+
+        Long memberId = memberService.joinGeneralMember(createMemberJoinParamOfEmail("email@email.com"));
+
+        given(dateTimeProvider.getNow()).willReturn(Optional.of(LocalDateTime.of(2023, 2, 2, 0, 0)));
+        memberService.deactivateMember(memberId);
+
+        // when
+        int deletedMembers = expiredMemberHandlerService.deleteMembersDeactivatedTimeBefore(LocalDateTime.of(2023, 3, 4, 0, 1).minusDays(30));
+        // then
+        assertThat(deletedMembers).isOne();
+    }
+
+    @Test
+    void 탈퇴한지_30일지난_애플_멤버_삭제됨() {
+        // given
+        handler.setDateTimeProvider(dateTimeProvider);
+
+        Long memberId = memberService.joinOauthMember(createOauthMemberJoinParamOfEmail("email@email.com"));
+
+        given(dateTimeProvider.getNow()).willReturn(Optional.of(LocalDateTime.of(2023, 2, 2, 0, 0)));
+        memberService.deactivateMember(memberId);
+
+        // when
+        int deletedMembers = expiredMemberHandlerService.deleteMembersDeactivatedTimeBefore(LocalDateTime.of(2023, 3, 4, 0, 1).minusDays(30));
+        // then
+        assertThat(deletedMembers).isOne();
+    }
+}

--- a/src/test/java/com/todoary/ms/src/service/MemberServiceTest.java
+++ b/src/test/java/com/todoary/ms/src/service/MemberServiceTest.java
@@ -10,9 +10,9 @@ import com.todoary.ms.src.repository.MemberRepository;
 import com.todoary.ms.src.repository.RefreshTokenRepository;
 import com.todoary.ms.src.s3.AwsS3Service;
 import com.todoary.ms.src.web.dto.MemberJoinParam;
+import com.todoary.ms.src.web.dto.OauthMemberJoinParam;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -27,7 +27,8 @@ import static com.todoary.ms.src.domain.Category.InitialCategoryValue.initialCol
 import static com.todoary.ms.src.domain.Category.InitialCategoryValue.initialTitle;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
 
 @Transactional
 @SpringBootTest
@@ -43,10 +44,8 @@ class MemberServiceTest {
     RefreshTokenRepository refreshTokenRepository;
     @Autowired
     FcmTokenRepository fcmTokenRepository;
-
     @MockBean
     AwsS3Service awsS3Service;
-
     @Value("${profile-image.default-url}")
     private String defaultProfileImageUrl;
 
@@ -61,6 +60,7 @@ class MemberServiceTest {
         assertThat(member.getEmail()).isEqualTo(memberJoinParam.getEmail());
         assertThat(member.getProviderAccount()).isEqualTo(ProviderAccount.none());
     }
+
     @Test
     void 같은_닉네임_일반멤버_회원가입_X() {
         // given
@@ -90,18 +90,78 @@ class MemberServiceTest {
     }
 
     @Test
+    void 같은_이메일_일반멤버_탈퇴했을때_재가입_O() {
+        // given
+        Long memberId = memberService.joinGeneralMember(createMemberJoinParam("nickname1", "email@email.com"));
+        memberService.findById(memberId).deactivate();
+        // when
+        MemberJoinParam memberJoinParam = createMemberJoinParam("nickname2", "email@email.com");
+        Long newMemberId = memberService.joinGeneralMember(memberJoinParam);
+        Member newMember = memberService.findById(newMemberId);
+        // then
+        assertThat(memberId).isNotEqualTo(newMemberId);
+        assertThat(newMember.getNickname()).isEqualTo("nickname2");
+    }
+
+    @Test
+    void 같은_이메일_애플멤버_탈퇴했을때_재가입_O() {
+        // given
+        Long memberId = memberService.joinOauthMember(createOauthMemberJoinParamOfEmail("email@email.com"));
+        memberService.findById(memberId).deactivate();
+        // when
+        Long newMemberId = memberService.joinOauthMember(createOauthMemberJoinParamOfEmail("email@email.com"));
+        Member newMember = memberService.findById(newMemberId);
+        // then
+        assertThat(memberId).isNotEqualTo(newMemberId);
+        assertThat(newMember.getEmail()).isEqualTo("email@email.com");
+        assertThatThrownBy(() -> memberService.findById(memberId))
+                .isInstanceOf(TodoaryException.class)
+                .matches(e -> ((TodoaryException) e).getStatus().equals(EMPTY_USER));
+    }
+
+    @Test
     void 존재하는_일반멤버_이메일로_조회O() {
         // given
         String email = "email";
         MemberJoinParam memberJoinParam = createMemberJoinParamOfEmail(email);
         memberService.joinGeneralMember(memberJoinParam);
         // when
-        Member member = memberService.findGeneralMemberByEmail(email);
+        Member member = memberService.findActiveGeneralMemberByEmail(email);
         // then
         assertThat(member.getEmail()).isEqualTo(email);
         assertThat(ProviderAccount.none()).isEqualTo(ProviderAccount.none());
     }
 
+    @Test
+    void 탈퇴안한_존재하는_일반멤버_조회O() {
+        // given
+        memberService.joinGeneralMember(createMemberJoinParamOfEmail("email@email.com"));
+        // when
+        boolean exists = memberService.existsByGeneralEmail("email@email.com");
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    void 탈퇴한_존재하는_일반멤버_조회O() {
+        // given
+        Long memberId = memberService.joinGeneralMember(createMemberJoinParamOfEmail("email@email.com"));
+        memberService.deactivateMember(memberId);
+        // when
+        boolean exists = memberService.existsByGeneralEmail("email@email.com");
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    void 존재하지않는_일반멤버_조회X() {
+        // given
+        memberService.joinOauthMember(createOauthMemberJoinParamOfEmail("email@email.com"));
+        // when
+        boolean exists = memberService.existsByGeneralEmail("email@email.com");
+        // then
+        assertThat(exists).isFalse();
+    }
 
     @Test
     void 가입한_일반멤버_id_조회O() {
@@ -112,7 +172,7 @@ class MemberServiceTest {
         Member member = memberService.findById(joinMemberId);
         // then
         assertThat(member.getId()).isEqualTo(joinMemberId);
-        assertThat(member.isDeleted()).isFalse();
+        assertThat(member.isDeactivated()).isFalse();
     }
 
     @Test
@@ -157,7 +217,7 @@ class MemberServiceTest {
         MemberJoinParam memberJoinParam = createMemberJoinParam();
         Long joinMemberId = memberService.joinGeneralMember(memberJoinParam);
         // when
-        memberService.removeMember(joinMemberId);
+        memberService.deactivateMember(joinMemberId);
         // then
         assertThatThrownBy(() -> memberService.findById(joinMemberId))
                 .isInstanceOf(TodoaryException.class)
@@ -170,10 +230,10 @@ class MemberServiceTest {
         MemberJoinParam memberJoinParam = createMemberJoinParam();
         Long joinMemberId = memberService.joinGeneralMember(memberJoinParam);
         // when
-        memberService.removeMember(joinMemberId);
+        memberService.deactivateMember(joinMemberId);
         Member member = memberRepository.findById(joinMemberId).get();
         // then
-        assertThat(member.isDeleted()).isTrue();
+        assertThat(member.isDeactivated()).isTrue();
     }
 
     @Test
@@ -182,7 +242,7 @@ class MemberServiceTest {
         MemberJoinParam memberJoinParam = createMemberJoinParam();
         Long joinMemberId = memberService.joinGeneralMember(memberJoinParam);
         // when
-        memberService.removeMember(joinMemberId);
+        memberService.deactivateMember(joinMemberId);
         Member member = memberRepository.findById(joinMemberId).get();
         // then
         assertThat(member.getRefreshToken()).isNull();
@@ -194,8 +254,8 @@ class MemberServiceTest {
     void 멤버_동등성_검사_이메일과_provider기준() {
         // given
         String email = "email";
-        String providerId= "1234";
-       // when
+        String providerId = "1234";
+        // when
         Member member1 = Member.builder().email(email).providerAccount(ProviderAccount.appleFrom(providerId)).build();
         Member member2 = Member.builder().email(email).providerAccount(ProviderAccount.appleFrom(providerId)).build();
         // then
@@ -284,7 +344,37 @@ class MemberServiceTest {
         assertThat(findMember.getProfileImgUrl()).isEqualTo(defaultProfileImageUrl);
     }
 
-    MemberJoinParam createMemberJoinParam(String nickname, String email) {
+    @Test
+    void 존재하지_않는_멤버의_탈퇴여부_조회_false() {
+        // given
+        // when
+        boolean isUsed = memberService.isEmailUsedByDeactivatedGeneralMember("email@email.com");
+        // then
+        assertThat(isUsed).isFalse();
+    }
+
+    @Test
+    void 탈퇴하지_않은_멤버의_탈퇴여부_조회_false() {
+        // given
+        memberService.joinGeneralMember(createMemberJoinParamOfEmail("email@email.com"));
+        // when
+        boolean isUsed = memberService.isEmailUsedByDeactivatedGeneralMember("email@email.com");
+        // then
+        assertThat(isUsed).isFalse();
+    }
+
+    @Test
+    void 탈퇴한_멤버의_탈퇴여부_조회_true() {
+        // given
+        Long memberId = memberService.joinGeneralMember(createMemberJoinParamOfEmail("email@email.com"));
+        memberService.deactivateMember(memberId);
+        // when
+        boolean isUsed = memberService.isEmailUsedByDeactivatedGeneralMember("email@email.com");
+        // then
+        assertThat(isUsed).isTrue();
+    }
+
+    static MemberJoinParam createMemberJoinParam(String nickname, String email) {
         return new MemberJoinParam("memberA",
                                    nickname,
                                    email,
@@ -293,15 +383,19 @@ class MemberServiceTest {
                                    true);
     }
 
-    MemberJoinParam createMemberJoinParamOfEmail(String email) {
+    static MemberJoinParam createMemberJoinParamOfEmail(String email) {
         return createMemberJoinParam("nicknameA", email);
     }
 
-    MemberJoinParam createMemberJoinParamOfNickname(String nickname) {
+    static MemberJoinParam createMemberJoinParamOfNickname(String nickname) {
         return createMemberJoinParam(nickname, "emailA");
     }
 
-    MemberJoinParam createMemberJoinParam() {
+    static MemberJoinParam createMemberJoinParam() {
         return createMemberJoinParam("nicknameA", "emailA");
+    }
+
+    static OauthMemberJoinParam createOauthMemberJoinParamOfEmail(String email) {
+        return new OauthMemberJoinParam("name", email, ProviderAccount.appleFrom("1234"), "USER_ROLE", true);
     }
 }

--- a/src/test/java/com/todoary/ms/src/service/MemberServiceTest.java
+++ b/src/test/java/com/todoary/ms/src/service/MemberServiceTest.java
@@ -251,13 +251,21 @@ class MemberServiceTest {
     }
 
     @Test
-    void 멤버_동등성_검사_이메일과_provider기준() {
+    void 소셜멤버_동등성_검사_provider기준() {
         // given
-        String email = "email";
-        String providerId = "1234";
+        Member member1 = Member.builder().email("email1").providerAccount(ProviderAccount.appleFrom("providerId")).build();
+        Member member2 = Member.builder().email("email2").providerAccount(ProviderAccount.appleFrom("providerId")).build();
         // when
-        Member member1 = Member.builder().email(email).providerAccount(ProviderAccount.appleFrom(providerId)).build();
-        Member member2 = Member.builder().email(email).providerAccount(ProviderAccount.appleFrom(providerId)).build();
+        // then
+        assertThat(member1).isEqualTo(member2);
+    }
+
+    @Test
+    void 일반멤버_동등성_검사_email기준() {
+        // given
+        Member member1 = Member.builder().email("email").providerAccount(ProviderAccount.none()).build();
+        Member member2 = Member.builder().email("email").providerAccount(ProviderAccount.none()).build();
+        // when
         // then
         assertThat(member1).isEqualTo(member2);
     }

--- a/src/test/java/com/todoary/ms/src/web/controller/AuthControllerTest.java
+++ b/src/test/java/com/todoary/ms/src/web/controller/AuthControllerTest.java
@@ -36,9 +36,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-// @Transactional
-// @SpringBootTest
-// @AutoConfigureMockMvc
 @WebMvcTest(value = AuthController.class)
 @WithMockUser(roles = "GUEST")
 class AuthControllerTest {

--- a/src/test/java/com/todoary/ms/src/web/controller/AuthControllerTest.java
+++ b/src/test/java/com/todoary/ms/src/web/controller/AuthControllerTest.java
@@ -303,7 +303,7 @@ class AuthControllerTest {
         tokenResponse.put("refresh_token", "appleRefreshToken");
 
         when(appleAuthService.getTokenResponseByCode(anyString())).thenReturn(new JSONObject(tokenResponse));
-        when(memberService.findActiveMemberByProviderEmail(any(), any())).thenReturn(createMemberWithId(1L));
+        when(memberService.findActiveMemberByProviderAccount(any())).thenReturn(createMemberWithId(1L));
 
         //when
         mockMvc.perform(

--- a/src/test/java/com/todoary/ms/src/web/controller/AuthControllerTest.java
+++ b/src/test/java/com/todoary/ms/src/web/controller/AuthControllerTest.java
@@ -14,30 +14,33 @@ import com.todoary.ms.src.web.dto.MemberJoinParam;
 import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.todoary.ms.src.common.response.BaseResponseStatus.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@Transactional
-@SpringBootTest
-@AutoConfigureMockMvc
+// @Transactional
+// @SpringBootTest
+// @AutoConfigureMockMvc
+@WebMvcTest(value = AuthController.class)
+@WithMockUser(roles = "GUEST")
 class AuthControllerTest {
     @Autowired
     private MockMvc mockMvc;
@@ -58,7 +61,7 @@ class AuthControllerTest {
 
         String requestBody = "{\"refreshToken\" : \"formalRefreshToken\"}";
         mockMvc.perform(
-                        post("/auth/jwt")
+                        post("/auth/jwt").with(csrf())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(requestBody))
                 .andExpect(status().isOk())
@@ -78,7 +81,7 @@ class AuthControllerTest {
                 "\"isTermsEnable\" : true" +
                 "}";
         mockMvc.perform(
-                        MockMvcRequestBuilders.post("/auth/signup")
+                        MockMvcRequestBuilders.post("/auth/signup").with(csrf())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(normalJoinRequestBody))
                 .andExpect(status().isOk())
@@ -101,7 +104,7 @@ class AuthControllerTest {
                 "}";
 
         mockMvc.perform(
-                        post("/auth/signin")
+                        post("/auth/signin").with(csrf())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(loginRequestBody))
                 .andExpect(status().isOk())
@@ -122,7 +125,7 @@ class AuthControllerTest {
                         "\"password\" : \"passwordA\"" +
                         "}";
         mockMvc.perform(
-                        post("/auth/signin")
+                        post("/auth/signin").with(csrf())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(loginRequestBody))
                 .andExpect(status().isOk())
@@ -145,7 +148,7 @@ class AuthControllerTest {
                         "\"password\" : \"passwordA\"" +
                         "}";
         mockMvc.perform(
-                        post("/auth/signin")
+                        post("/auth/signin").with(csrf())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(loginRequestBody))
                 .andExpect(status().isOk())
@@ -169,7 +172,7 @@ class AuthControllerTest {
                         "}";
 
         mockMvc.perform(
-                        post("/auth/signin/auto")
+                        post("/auth/signin/auto").with(csrf())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(autoLoginRequestBody))
                 .andExpect(status().isOk())
@@ -197,7 +200,8 @@ class AuthControllerTest {
                         get("/auth/email/duplication")
                                 .queryParam("email", "newEmail"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result").value("가능한 이메일입니다."))
+                .andExpect(jsonPath("$.code").value("2019"))
+                .andExpect(jsonPath("$.message").value("사용 가능한 이메일입니다."))
                 .andDo(print());
     }
     
@@ -212,7 +216,7 @@ class AuthControllerTest {
                         "\"newPassword\" : \"" + newPassword + "\"" +
                         "}";
 
-        mockMvc.perform(patch("/auth/password")
+        mockMvc.perform(patch("/auth/password").with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(changePasswordRequestBody))
                 .andExpect(jsonPath("$.code").value("1000"))
@@ -234,8 +238,8 @@ class AuthControllerTest {
         tokenResponse.put("id_token", "idToken");
         tokenResponse.put("refresh_token", "appleRefreshToken");
 
-        when(memberService.existsByProviderAccount(any())).thenReturn(false);
-        when(memberService.findByProviderAccount(any())).thenReturn(createMemberWithId(1L));
+        when(memberService.existsActiveMemberByProviderAccount(any())).thenReturn(false);
+        when(memberService.findActiveMemberByProviderAccount(any())).thenReturn(createMemberWithId(1L));
         when(memberService.joinOauthMember(any())).thenReturn(1L);
         when(authService.issueAccessToken(anyLong())).thenReturn(new AccessToken("accessToken"));
         when(authService.issueRefreshToken(anyLong())).thenReturn(new RefreshToken(Member.builder().build(), "refreshToken"));
@@ -245,7 +249,7 @@ class AuthControllerTest {
 
         //when
         mockMvc.perform(
-                        post("/auth/apple/token")
+                        post("/auth/apple/token").with(csrf())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(new ObjectMapper().writeValueAsString(appleSigninRequest)))
                 .andExpect(status().isOk())
@@ -269,8 +273,8 @@ class AuthControllerTest {
         tokenResponse.put("id_token", "idToken");
         tokenResponse.put("refresh_token", "appleRefreshToken");
 
-        when(memberService.existsByProviderAccount(any())).thenReturn(true);
-        when(memberService.findByProviderAccount(any())).thenReturn(createMemberWithId(1L));
+        when(memberService.existsActiveMemberByProviderAccount(any())).thenReturn(true);
+        when(memberService.findMemberOrEmptyByProviderAccount(any())).thenReturn(Optional.ofNullable(createMemberWithId(1L)));
         when(memberService.joinOauthMember(any())).thenReturn(1L);
         when(authService.issueAccessToken(anyLong())).thenReturn(new AccessToken("accessToken"));
         when(authService.issueRefreshToken(anyLong())).thenReturn(new RefreshToken(Member.builder().build(), "refreshToken"));
@@ -280,13 +284,14 @@ class AuthControllerTest {
 
         //when
         mockMvc.perform(
-                        post("/auth/apple/token")
+                        post("/auth/apple/token").with(csrf())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(new ObjectMapper().writeValueAsString(appleSigninRequest)))
                 .andExpect(status().isOk())
                 .andDo(print())
                 .andExpect(jsonPath("$.code").value("1000"))
-                .andExpect(jsonPath("$.result.isNewUser").value(false));
+                .andExpect(jsonPath("$.result.isNewUser").value(false))
+                .andExpect(jsonPath("$.result.isDeactivatedUser").value(false));
     }
 
     @Test
@@ -301,18 +306,18 @@ class AuthControllerTest {
         tokenResponse.put("refresh_token", "appleRefreshToken");
 
         when(appleAuthService.getTokenResponseByCode(anyString())).thenReturn(new JSONObject(tokenResponse));
-        when(memberService.findByProviderEmail(any(), any())).thenReturn(createMemberWithId(1L));
+        when(memberService.findActiveMemberByProviderEmail(any(), any())).thenReturn(createMemberWithId(1L));
 
         //when
         mockMvc.perform(
-                        post("/auth/revoke/apple")
+                        post("/auth/revoke/apple").with(csrf())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(new ObjectMapper().writeValueAsString(appleRevokeRequest)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("1000"))
                 .andReturn();
     }
-    
+
     public Member createMemberWithId(Long id) throws NoSuchFieldException, IllegalAccessException {
         Member member = Member.builder().build();
         Field idField = member.getClass().getDeclaredField("id");


### PR DESCRIPTION
## What is this PR? 🔍
- 탈퇴 후 복구 기능 추가에 따른 여러 기능 추가

## Changes 📝
- 이메일 중복 조회 api에 탈퇴한 멤버 응답 추가
- 30일 지난 멤버 삭제하는 scheduler 추가
- 탈퇴한 멤버 복구 api 추가
- 회원가입 시 탈퇴한 멤버일 경우 기존 내용 삭제하고 새로 회원가입
- AuthControllerTest시 mockMvc로 테스트하는데 @SpringBootTest로 되어있어서 빠른 테스트를 위해 @WebMvcTest로 수정
- ✅ 소셜 계정 비교시 email까지 비교하는 로직에서 email 말고 Provider Account만 비교하도록 했습니다. 이게 테스트하다 보니까 매번 이메일을 가릴지 안가릴지 선택할 수가 있어서 email로 비교해버리면 제대로 비교를 못할 때가 있더라구요.. 그래서 Member에서 Equals 오버라이딩할 때 소셜 계정이 아닐 땐 이메일 비교, 소셜 계정일 땐 ProviderAccount를 비교하는 식으로 수정했습니다.

## Test Checklist ☑️
- [X] 탈퇴여부 조회 테스트
- [X] 탈퇴한 지 30일 지난 경우 삭제되는 지 테스트

## To Reviewers 📢
- 애플쪽은 수정하긴 했으나 잘 모르겠네요... 일단 테스트 서버에 올려서 확인은 했습니다.
- 컨트롤러 테스트 코드는 추가 못했는데 로컬에서 RDS 연결해서 각 경우마다 한번씩 실행은 해봤습니다. 빠른 시일 내에 추가하겠습니다!

