### PR TITLE
feat: 기본 프로필 이미지 변경한다

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: deploy
+name: test-deploy
 
 # Controls when the workflow will run
 on:
@@ -29,54 +29,43 @@ jobs:
           java-version: '11'
           distribution: 'temurin' # https://github.com/actions/setup-java
 
-      - name: Gradle Caching
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
         shell: bash
 
       - name: Build with Gradle
-        run: ./gradlew clean build -x test --info
+        run: ./gradlew clean build -x test
         shell: bash
 
       - name: Test with Gradle
         run: ./gradlew test
 
-      - name: zip 파일 생성
-        run: |
-          mkdir -p before-deploy
-          cp service-scripts/*.sh before-deploy/
-          cp appspec.yml before-deploy/
-          cp $(ls -tr build/libs/*.jar | tail -n 1) before-deploy/
-          cd before-deploy && zip -r before-deploy *
-          cd ../ && mkdir -p deploy
-          mv before-deploy/before-deploy.zip deploy/todoary-service$GITHUB_SHA.zip
-        shell: bash
-
-      - name: AWS 자격 증명
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Deploy
+        uses: appleboy/ssh-action@master
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-          aws-region: ap-northeast-2
+          host: ${{ secrets.REMOTE_IP }}
+          username: ${{ secrets.REMOTE_SSH_ID }}
+          key: ${{ secrets.REMOTE_SSH_KEY }}
+          port: ${{ secrets.REMOTE_SSH_PORT }}
+          script: |
+            whoami
+            cd /home/ubuntu/todoary/dev/project
+             echo -e "\
+             +------------------------------------+
+             |              1. build              |
+             +------------------------------------+"
+            
+            echo ">>>>>> making auth key..."
+            echo "${{ secrets.AUTH_KEY }}" > ./src/main/resources/static/AuthKey_Q97Q56DJS6.p8
+            
+            echo -e "\
+             >>>>>> git pull... "
+            cd "/home/ubuntu/todoary/test/project" || exit 1
+            git fetch --all || exit 1
+            git reset --hard origin/Test || exit 1
+            git pull origin Test || exit 1
+            git submodule update --remote --force || exit 1
 
-      - name: S3 로드
-        run: |
-          aws s3 cp \
-          --region ap-northeast-2 \
-          ./deploy/todoary-service$GITHUB_SHA.zip s3://todoary-service-s3/artifacts/todoary-service$GITHUB_SHA.zip
-
-      - name: CodeDeploy 배포
-        run: |
-          aws deploy create-deployment \
-          --application-name todoary-service \
-          --deployment-group-name todoary-service-group \
-          --s3-location bucket=todoary-service-s3,bundleType=zip,key=artifacts/todoary-service$GITHUB_SHA.zip
+            ./test-scripts/build.sh || exit 1
+            ./test-scripts/stop.sh || exit 1
+            ./test-scripts/start.sh || exit 1

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@
 
 **Subject**
 
-- 50자를 넘기지 않고 대문자로 작성
 - 과거시제를 사용하지 않고 명령어로 작성 (ex : Fixed → Fix,  Added → Add)
 
 **commit message**

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
       → PR 코드 리뷰 필수 입니다. 
 
-- Feature : 기능을 개발하는 브랜치 (ex : Feature-Login)
+- Feature : 기능을 개발하는 브랜치 
 - Bugfix : 최종 런칭 버전개발 과정에서 발생한 버그를 수정하는 브렌치
 - Release : 제품으로 출시될 수 있는 브랜치
 - Hotfix : 출시 버전에서 발생한 버그를 수정 하는 브랜치
@@ -21,17 +21,8 @@
 
 ### Todoary commit 컨벤션
 
-```
-[commit type] : subject
-v
-[commit message]
-```
-
-**commit type**
-
-- feat -  새 기능 구현 (ex : [feat] : Add_ local_login&social_login)
-- fix - 에러 수정 (ex : [fix] : local_login_errorfix)
-
+- feat -  새 기능 구현
+- fix - 에러 수정
 - style - 코드 변경이 없는 경우, 코드 포멧팅
 - refactor - 코드 리펙토링
 - rename - 파일, 폴더명만 수정하거나 이동하는 작업
@@ -47,12 +38,3 @@ v
 - 커밋에서 작업한 내용을 간략하게 설명합니다.
 - 선택사항이기 때문에 모든 커밋에 작성할 필요는 없습니다.
 - 제목과 구분되도록 한칸 띄워 작성합니다.
-
-```
-ex) 
-
-[Feat] : Add_ local_login&social_login
-v
-소셜로그인 이메일 중복확인 API 개발
-로컬로그인 아이디, 비밀번호 저장 개발
-```

--- a/build.gradle
+++ b/build.gradle
@@ -74,9 +74,12 @@ dependencies {
     // 스프링 시큐리티 테스트
     testImplementation('org.springframework.security:spring-security-test')
 
-    // querydsl 이놈
+    // querydsl
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+
+    // base responses
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/todoary/ms/src/common/auth/PrincipalOAuth2UserService.java
+++ b/src/main/java/com/todoary/ms/src/common/auth/PrincipalOAuth2UserService.java
@@ -30,7 +30,7 @@ public class PrincipalOAuth2UserService extends DefaultOAuth2UserService {
         String provider = userRequest.getClientRegistration().getRegistrationId();
         String provider_id = (String) oAuth2User.getAttributes().get("sub");
 
-        ProviderAccount providerAccount = ProviderAccount.from(provider, provider_id);
+        ProviderAccount providerAccount = ProviderAccount.of(provider, provider_id);
         Member member = memberService.findActiveMemberByEmailAndProviderAccount(email, providerAccount);
 
         if (member == null) {

--- a/src/main/java/com/todoary/ms/src/config/SecurityConfig.java
+++ b/src/main/java/com/todoary/ms/src/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import com.todoary.ms.src.legacy.user.LegacyUserProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -66,6 +67,8 @@ public class SecurityConfig {
                 .antMatchers("/test").permitAll()
                 // profile check
                 .antMatchers("/profile").permitAll()
+                // base response status
+                .antMatchers(HttpMethod.GET, "/responses").permitAll()
                 .and()
                 .authorizeRequests()
                 .anyRequest().authenticated()

--- a/src/main/java/com/todoary/ms/src/domain/ProviderAccount.java
+++ b/src/main/java/com/todoary/ms/src/domain/ProviderAccount.java
@@ -42,10 +42,6 @@ public class ProviderAccount {
         return new ProviderAccount(Provider.GOOGLE, providerId);
     }
 
-    public static ProviderAccount from(String provider, String provider_id) {
-        return new ProviderAccount(Provider.findByProviderName(provider), provider_id);
-    }
-
     public static ProviderAccount of(String provider, String providerId) {
         if (provider.equalsIgnoreCase("apple")) {
             return appleFrom(providerId);

--- a/src/main/java/com/todoary/ms/src/repository/MemberRepository.java
+++ b/src/main/java/com/todoary/ms/src/repository/MemberRepository.java
@@ -145,4 +145,13 @@ public class MemberRepository {
                 .setParameter("time", time)
                 .getResultList();
     }
+
+    public boolean existById(Long memberId) {
+        Integer fetchOne = queryFactory
+                .selectOne()
+                .from(member)
+                .where(member.id.eq(memberId))
+                .fetchFirst();
+        return fetchOne != null;
+    }
 }

--- a/src/main/java/com/todoary/ms/src/service/AuthService.java
+++ b/src/main/java/com/todoary/ms/src/service/AuthService.java
@@ -6,6 +6,7 @@ import com.todoary.ms.src.domain.Member;
 import com.todoary.ms.src.domain.token.AccessToken;
 import com.todoary.ms.src.domain.token.RefreshToken;
 import com.todoary.ms.src.common.exception.TodoaryException;
+import com.todoary.ms.src.web.dto.Token;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -40,17 +41,6 @@ public class AuthService {
         return memberId == Long.parseLong(jwtTokenProvider.getUserIdFromAccessToken(accessTokenCode));
     }
 
-    public RefreshToken createRefreshToken(Member member) {
-        String code = jwtTokenProvider.createRefreshToken(member.getId());
-        if (member.hasRefreshToken()) {
-            return member.updateRefreshToken(code);
-        } else {
-            RefreshToken refreshToken = new RefreshToken(member, code);
-            refreshTokenService.save(refreshToken);
-            return refreshToken;
-        }
-    }
-
     public Long authenticate(String email, String password) {
         try {
             UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(email, password);
@@ -81,23 +71,49 @@ public class AuthService {
         }
     }
 
-    public AccessToken issueAccessToken(Long memberId) {
+    public Token issueTokens(Long memberId) {
         memberService.checkMemberExistsById(memberId);
-        return new AccessToken(jwtTokenProvider.createAccessToken(memberId));
+        return Token.builder()
+                .accessToken(createAccessToken(memberId).getCode())
+                .refreshToken(createRefreshToken(memberId).getCode())
+                .build();
     }
 
-    public AccessToken issueAccessToken(String refreshTokenCode) {
-        return issueAccessToken(Long.parseLong(jwtTokenProvider.getUserIdFromRefreshToken(refreshTokenCode)));
+    public AccessToken issueAccessToken(Long memberId) {
+        memberService.checkMemberExistsById(memberId);
+        return createAccessToken(memberId);
     }
 
     public RefreshToken issueRefreshToken(Long memberId) {
-        Member findMember = memberService.findMemberById(memberId);
-        RefreshToken refreshToken = createRefreshToken(findMember);
-
-        return refreshToken;
+        memberService.checkMemberExistsById(memberId);
+        return createRefreshToken(memberId);
+    }
+    private AccessToken createAccessToken(Long memberId) {
+        return new AccessToken(jwtTokenProvider.createAccessToken(memberId));
     }
 
-    public RefreshToken issueRefreshToken(String refreshTokenCode) {
+    private RefreshToken createRefreshToken(Long memberId) {
+        Member member = memberService.findMemberById(memberId);
+        return createRefreshToken(member);
+    }
+
+    private RefreshToken createRefreshToken(Member member) {
+        String code = jwtTokenProvider.createRefreshToken(member.getId());
+        if (member.hasRefreshToken()) {
+            return member.updateRefreshToken(code);
+        } else {
+            RefreshToken refreshToken = new RefreshToken(member, code);
+            refreshTokenService.save(refreshToken);
+            return refreshToken;
+        }
+    }
+
+    public AccessToken issueAccessTokenFromRefreshTokenCode(String refreshTokenCode) {
+        return issueAccessToken(Long.parseLong(jwtTokenProvider.getUserIdFromRefreshToken(refreshTokenCode)));
+    }
+
+    public RefreshToken issueRefreshTokenFromRefreshTokenCode(String refreshTokenCode) {
         return issueRefreshToken(Long.parseLong(jwtTokenProvider.getUserIdFromRefreshToken(refreshTokenCode)));
     }
+
 }

--- a/src/main/java/com/todoary/ms/src/service/AuthService.java
+++ b/src/main/java/com/todoary/ms/src/service/AuthService.java
@@ -82,8 +82,7 @@ public class AuthService {
     }
 
     public AccessToken issueAccessToken(Long memberId) {
-        Member findMember = memberService.findById(memberId);
-
+        memberService.checkMemberExistsById(memberId);
         return new AccessToken(jwtTokenProvider.createAccessToken(memberId));
     }
 
@@ -92,7 +91,7 @@ public class AuthService {
     }
 
     public RefreshToken issueRefreshToken(Long memberId) {
-        Member findMember = memberService.findById(memberId);
+        Member findMember = memberService.findMemberById(memberId);
         RefreshToken refreshToken = createRefreshToken(findMember);
 
         return refreshToken;

--- a/src/main/java/com/todoary/ms/src/service/CategoryService.java
+++ b/src/main/java/com/todoary/ms/src/service/CategoryService.java
@@ -23,14 +23,14 @@ public class CategoryService {
 
     @Transactional
     public Long saveCategory(Long memberId, CategoryRequest request) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
         validateMembersCategoryTitle(member, request.getTitle());
         return categoryRepository.save(request.toEntity(member)).getId();
     }
 
     @Transactional
     public void updateCategory(Long memberId, Long categoryId, CategoryRequest request) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
         Category category = findCategoryByIdAndMember(categoryId, member);
         if (!category.hasTitle(request.getTitle())) {
             validateMembersCategoryTitle(member, request.getTitle());
@@ -52,7 +52,7 @@ public class CategoryService {
 
     @Transactional(readOnly = true)
     public CategoryResponse[] findCategories(Long memberId) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
         return member.getCategories()
                 .stream().map(c -> new CategoryResponse(
                         c.getId(), c.getTitle(), c.getColor().getCode())
@@ -61,7 +61,7 @@ public class CategoryService {
 
     @Transactional(readOnly = true)
     public Category findCategoryByIdAndMember(Long categoryId, Long memberId) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
         return findCategoryByIdAndMember(categoryId, member);
     }
 

--- a/src/main/java/com/todoary/ms/src/service/DiaryService.java
+++ b/src/main/java/com/todoary/ms/src/service/DiaryService.java
@@ -35,7 +35,7 @@ public class DiaryService {
 
     @Transactional
     public void saveDiaryOrUpdate(Long memberId, DiaryRequest request, LocalDate createdDate) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
         findDiaryByDateIfExists(createdDate, member)
                 .ifPresentOrElse(
                         diary -> diary.update(request.getTitle(), request.getContent()),
@@ -51,7 +51,7 @@ public class DiaryService {
 
     @Transactional
     public void deleteDiary(Long memberId, LocalDate createdDate) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
         Diary diary = findDiaryByDate(createdDate, member);
         diary.removeAssociations();
         diaryRepository.delete(diary);
@@ -59,7 +59,7 @@ public class DiaryService {
 
     @Transactional(readOnly = true)
     public DiaryResponse retrieveDiaryByDate(LocalDate createdDate, Long memberId) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
         return findDiaryByDateIfExists(createdDate, member)
                 .map(DiaryResponse::from)
                 .orElse(null);
@@ -67,7 +67,7 @@ public class DiaryService {
 
     @Transactional(readOnly = true)
     public List<Integer> findDaysHavingDiaryInMonth(Long memberId, YearMonth yearMonth) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
 
         LocalDate firstDay = yearMonth.atDay(1);
         LocalDate lastDay = yearMonth.atEndOfMonth();
@@ -91,7 +91,7 @@ public class DiaryService {
 
     @Transactional(readOnly = true)
     public List<StickerResponse> retrieveStickersInDiaryOnDate(Long memberId, LocalDate createdDate) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
         Diary diary = findDiaryByDate(createdDate, member);
         return diary.getStickers()
                 .stream().map(StickerResponse::from).collect(Collectors.toList());
@@ -112,7 +112,7 @@ public class DiaryService {
         if (requests == null || requests.isEmpty()) {
             return null;
         }
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
         Diary diary = findDiaryByDate(createdDate, member);
         return stickerRepository.saveAll(
                         requests.stream()

--- a/src/main/java/com/todoary/ms/src/service/MemberService.java
+++ b/src/main/java/com/todoary/ms/src/service/MemberService.java
@@ -146,12 +146,20 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public Member findActiveMemberByEmailAndProviderAccount(String email, ProviderAccount providerAccount) {
-        return checkMemberValid(memberRepository.findByEmailAndProviderAccount(email, providerAccount));
+        return checkMemberValid(findMemberOrEmptyByEmailAndProviderAccount(email, providerAccount));
     }
 
     @Transactional(readOnly = true)
     public Member findMemberByEmailAndProviderAccount(String email, ProviderAccount providerAccount) {
-        return checkMemberExists(memberRepository.findByEmailAndProviderAccount(email, providerAccount));
+        return checkMemberExists(findMemberOrEmptyByEmailAndProviderAccount(email, providerAccount));
+    }
+
+    private Optional<Member> findMemberOrEmptyByEmailAndProviderAccount(String email, ProviderAccount providerAccount) {
+        if (providerAccount.isGeneral()) {
+            return memberRepository.findGeneralMemberByEmail(email);
+        }else {
+            return memberRepository.findByProviderAccount(providerAccount);
+        }
     }
 
     private void checkEmailAndOAuthAccountNotUsed(String email, ProviderAccount providerAccount) {

--- a/src/main/java/com/todoary/ms/src/service/alarm/AlarmService.java
+++ b/src/main/java/com/todoary/ms/src/service/alarm/AlarmService.java
@@ -9,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -18,7 +17,7 @@ public class AlarmService {
     
     @Transactional
     public void updateRemindAlarmToDate(Long memberId, LocalDate alarmDate) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
         member.changeRemindAlarm(new RemindAlarm(member, alarmDate));
     }
 

--- a/src/main/java/com/todoary/ms/src/service/todo/TodoService.java
+++ b/src/main/java/com/todoary/ms/src/service/todo/TodoService.java
@@ -34,7 +34,7 @@ public class TodoService {
 
     @Transactional
     public Long createMembersTodo(Long memberId, TodoRequest request) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
         Category category = categoryService.findCategoryByIdAndMember(request.getCategoryId(), member);
         return todoRepository.save(
                 request.toEntity(member, category)
@@ -43,7 +43,7 @@ public class TodoService {
 
     @Transactional
     public TodoResponse updateMembersTodo(Long memberId, Long todoId, TodoRequest request) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
         Category category = categoryService.findCategoryByIdAndMember(request.getCategoryId(), member);
         Todo todo = findTodoByIdAndMember(todoId, member);
         todo.update(
@@ -58,7 +58,7 @@ public class TodoService {
 
     @Transactional
     public void deleteMembersTodo(Long memberId, Long todoId) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
         Todo todo = findTodoByIdAndMember(todoId, member);
         todo.removeAssociations();
         todoRepository.delete(todo);
@@ -66,21 +66,21 @@ public class TodoService {
 
     @Transactional
     public void updateMembersTodoMarkedStatus(Long memberId, Long todoId, boolean isChecked) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
         Todo todo = findTodoByIdAndMember(todoId, member);
         todo.check(isChecked);
     }
 
     @Transactional
     public void updateMembersTodoPinnedStatus(Long memberId, Long todoId, boolean isPinned) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
         Todo todo = findTodoByIdAndMember(todoId, member);
         todo.pin(isPinned);
     }
 
     @Transactional
     public void updateMembersTodoAlarm(Long memberId, Long todoId, TodoAlarmRequest request) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
         Todo todo = findTodoByIdAndMember(todoId, member);
         todo.updateAlarm(
                 request.getIsAlarmEnabled(),
@@ -91,7 +91,7 @@ public class TodoService {
 
     @Transactional(readOnly = true)
     public List<TodoResponse> retrieveMembersTodosOnDate(Long memberId, LocalDate targetDate) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
         return todoRepository.findByDateAndMember(targetDate, member)
                 .stream().map(TodoResponse::from).collect(Collectors.toList());
     }
@@ -122,7 +122,7 @@ public class TodoService {
 
     @Transactional(readOnly = true)
     public List<Integer> retrieveDaysHavingTodoOfMemberInMonth(Long memberId, YearMonth yearMonth) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
         LocalDate firstDay = yearMonth.atDay(1);
         LocalDate lastDay = yearMonth.atEndOfMonth();
 

--- a/src/main/java/com/todoary/ms/src/service/todo/TodoService.java
+++ b/src/main/java/com/todoary/ms/src/service/todo/TodoService.java
@@ -33,7 +33,7 @@ public class TodoService {
     private final TodoByCategoryCondition todoByCategoryCondition;
 
     @Transactional
-    public Long saveTodo(Long memberId, TodoRequest request) {
+    public Long createMembersTodo(Long memberId, TodoRequest request) {
         Member member = memberService.findById(memberId);
         Category category = categoryService.findCategoryByIdAndMember(request.getCategoryId(), member);
         return todoRepository.save(
@@ -42,7 +42,7 @@ public class TodoService {
     }
 
     @Transactional
-    public TodoResponse updateTodo(Long memberId, Long todoId, TodoRequest request) {
+    public TodoResponse updateMembersTodo(Long memberId, Long todoId, TodoRequest request) {
         Member member = memberService.findById(memberId);
         Category category = categoryService.findCategoryByIdAndMember(request.getCategoryId(), member);
         Todo todo = findTodoByIdAndMember(todoId, member);
@@ -57,7 +57,7 @@ public class TodoService {
     }
 
     @Transactional
-    public void deleteTodo(Long memberId, Long todoId) {
+    public void deleteMembersTodo(Long memberId, Long todoId) {
         Member member = memberService.findById(memberId);
         Todo todo = findTodoByIdAndMember(todoId, member);
         todo.removeAssociations();
@@ -65,21 +65,21 @@ public class TodoService {
     }
 
     @Transactional
-    public void markTodoAsDone(Long memberId, Long todoId, boolean isChecked) {
+    public void updateMembersTodoMarkedStatus(Long memberId, Long todoId, boolean isChecked) {
         Member member = memberService.findById(memberId);
         Todo todo = findTodoByIdAndMember(todoId, member);
         todo.check(isChecked);
     }
 
     @Transactional
-    public void pinTodo(Long memberId, Long todoId, boolean isPinned) {
+    public void updateMembersTodoPinnedStatus(Long memberId, Long todoId, boolean isPinned) {
         Member member = memberService.findById(memberId);
         Todo todo = findTodoByIdAndMember(todoId, member);
         todo.pin(isPinned);
     }
 
     @Transactional
-    public void updateTodoAlarm(Long memberId, Long todoId, TodoAlarmRequest request) {
+    public void updateMembersTodoAlarm(Long memberId, Long todoId, TodoAlarmRequest request) {
         Member member = memberService.findById(memberId);
         Todo todo = findTodoByIdAndMember(todoId, member);
         todo.updateAlarm(
@@ -90,14 +90,14 @@ public class TodoService {
     }
 
     @Transactional(readOnly = true)
-    public List<TodoResponse> findTodosByDate(Long memberId, LocalDate targetDate) {
+    public List<TodoResponse> retrieveMembersTodosOnDate(Long memberId, LocalDate targetDate) {
         Member member = memberService.findById(memberId);
         return todoRepository.findByDateAndMember(targetDate, member)
                 .stream().map(TodoResponse::from).collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
-    public List<TodoResponse> findTodosByCategory(Long memberId, Long categoryId) {
+    public List<TodoResponse> retrieveMembersTodosByCategory(Long memberId, Long categoryId) {
         Category category = categoryService.findCategoryByIdAndMember(categoryId, memberId);
         return todoRepository.findByCategoryAndSatisfy(category, todoByCategoryCondition.getPredicate())
                 .stream().map(TodoResponse::from).collect(Collectors.toList());
@@ -121,7 +121,7 @@ public class TodoService {
     }
 
     @Transactional(readOnly = true)
-    public List<Integer> findDaysHavingTodoInMonth(Long memberId, YearMonth yearMonth) {
+    public List<Integer> retrieveDaysHavingTodoOfMemberInMonth(Long memberId, YearMonth yearMonth) {
         Member member = memberService.findById(memberId);
         LocalDate firstDay = yearMonth.atDay(1);
         LocalDate lastDay = yearMonth.atEndOfMonth();

--- a/src/main/java/com/todoary/ms/src/web/controller/AuthController.java
+++ b/src/main/java/com/todoary/ms/src/web/controller/AuthController.java
@@ -214,10 +214,6 @@ public class AuthController {
             memberDeactivated = member.get().isDeactivated();
             memberId = member.get().getId();
         }
-        Token token = null;
-        if (!memberDeactivated) {
-            token = new Token(authService.issueAccessToken(memberId).getCode(), authService.issueRefreshToken(memberId).getCode());
-        }
         return new BaseResponse<>(new AppleSigninResponse(
                 !memberExists,
                 memberDeactivated,
@@ -225,7 +221,7 @@ public class AuthController {
                 appleSigninRequest.getEmail(),
                 providerAccount.getProvider().name(),
                 providerAccount.getProviderId(),
-                token,
+                new Token(authService.issueAccessToken(memberId).getCode(), authService.issueRefreshToken(memberId).getCode()),
                 appleRefreshToken
         ));
     }

--- a/src/main/java/com/todoary/ms/src/web/controller/AuthController.java
+++ b/src/main/java/com/todoary/ms/src/web/controller/AuthController.java
@@ -245,7 +245,7 @@ public class AuthController {
         return new BaseResponse<>(SUCCESS);
     }
 
-    @PostMapping("/restore")
+    @PatchMapping("/restore")
     public BaseResponse<BaseResponseStatus> activateMember(@RequestBody @Valid RestoreRequest request) {
         memberService.activateMember(
                 request.getEmail(), ProviderAccount.of(request.getProvider(), request.getProviderId()));

--- a/src/main/java/com/todoary/ms/src/web/controller/BaseResponseExampleController.java
+++ b/src/main/java/com/todoary/ms/src/web/controller/BaseResponseExampleController.java
@@ -1,0 +1,19 @@
+package com.todoary.ms.src.web.controller;
+
+import com.todoary.ms.src.common.response.BaseResponseStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+@Controller
+public class BaseResponseExampleController {
+
+    @GetMapping("/responses")
+    public String retrieveBaseResponseStatuses(Model model) {
+        model.addAttribute("responses", Arrays.stream(BaseResponseStatus.values()).sorted(Comparator.comparingInt(BaseResponseStatus::getCode)).toArray());
+        return "responses";
+    }
+}

--- a/src/main/java/com/todoary/ms/src/web/controller/MemberController.java
+++ b/src/main/java/com/todoary/ms/src/web/controller/MemberController.java
@@ -123,7 +123,7 @@ public class MemberController {
     // 2.8 알림 활성화 여부 조회 api
     @GetMapping("/alarm")
     public BaseResponse<AlarmEnablesResponse> getAlarmEnabled(@LoginMember Long memberId) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findActiveMemberById(memberId);
         return new BaseResponse<>(AlarmEnablesResponse.builder()
                                           .memberId(memberId)
                                           .toDoAlarmEnable(member.getToDoAlarmEnable())

--- a/src/main/java/com/todoary/ms/src/web/controller/TodoController.java
+++ b/src/main/java/com/todoary/ms/src/web/controller/TodoController.java
@@ -34,7 +34,7 @@ public class TodoController {
             @LoginMember Long memberId,
             @RequestBody @Valid TodoRequest request
     ) {
-        Long todoId = todoService.saveTodo(memberId, request);
+        Long todoId = todoService.createMembersTodo(memberId, request);
         return new BaseResponse<>(new TodoSaveResponse(todoId));
     }
 
@@ -45,7 +45,7 @@ public class TodoController {
             @PathVariable("todoId") Long todoId,
             @RequestBody @Valid TodoRequest request
     ) {
-        return new BaseResponse<>(todoService.updateTodo(memberId, todoId, request));
+        return new BaseResponse<>(todoService.updateMembersTodo(memberId, todoId, request));
     }
 
     // 3.3 투두 삭제
@@ -54,7 +54,7 @@ public class TodoController {
             @LoginMember Long memberId,
             @PathVariable("todoId") Long todoId
     ) {
-        todoService.deleteTodo(memberId, todoId);
+        todoService.deleteMembersTodo(memberId, todoId);
         return BaseResponse.from(SUCCESS);
     }
 
@@ -64,7 +64,7 @@ public class TodoController {
             @LoginMember Long memberId,
             @PathVariable("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate targetDate
     ) {
-        List<TodoResponse> todos = todoService.findTodosByDate(memberId, targetDate);
+        List<TodoResponse> todos = todoService.retrieveMembersTodosOnDate(memberId, targetDate);
         return new BaseResponse<>(todos);
     }
 
@@ -75,7 +75,7 @@ public class TodoController {
             @LoginMember Long memberId,
             @PathVariable("categoryId") Long categoryId
     ) {
-        List<TodoResponse> todos = todoService.findTodosByCategory(memberId, categoryId);
+        List<TodoResponse> todos = todoService.retrieveMembersTodosByCategory(memberId, categoryId);
         return new BaseResponse<>(todos);
     }
 
@@ -85,7 +85,7 @@ public class TodoController {
             @LoginMember Long memberId,
             @RequestBody @Valid MarkTodoRequest request
     ) {
-        todoService.markTodoAsDone(memberId, request.getTodoId(), request.getIsChecked());
+        todoService.updateMembersTodoMarkedStatus(memberId, request.getTodoId(), request.getIsChecked());
         return BaseResponse.from(SUCCESS);
     }
 
@@ -95,7 +95,7 @@ public class TodoController {
             @LoginMember Long memberId,
             @RequestBody @Valid PinTodoRequest request
     ) {
-        todoService.pinTodo(memberId, request.getTodoId(), request.getIsPinned());
+        todoService.updateMembersTodoPinnedStatus(memberId, request.getTodoId(), request.getIsPinned());
         return BaseResponse.from(SUCCESS);
     }
 
@@ -105,7 +105,7 @@ public class TodoController {
             @LoginMember Long memberId,
             @PathVariable("yearMonth") @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth
     ) {
-        List<Integer> days = todoService.findDaysHavingTodoInMonth(memberId, yearMonth);
+        List<Integer> days = todoService.retrieveDaysHavingTodoOfMemberInMonth(memberId, yearMonth);
         return new BaseResponse<>(days);
     }
 
@@ -116,7 +116,7 @@ public class TodoController {
             @PathVariable("todoId") Long todoId,
             @RequestBody @Valid TodoAlarmRequest request
     ) {
-        todoService.updateTodoAlarm(memberId, todoId, request);
+        todoService.updateMembersTodoAlarm(memberId, todoId, request);
         return BaseResponse.from(SUCCESS);
     }
 

--- a/src/main/java/com/todoary/ms/src/web/dto/RestoreRequest.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/RestoreRequest.java
@@ -1,13 +1,11 @@
 package com.todoary.ms.src.web.dto;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.validation.constraints.NotNull;
 
 @Getter
+@ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class RestoreRequest {

--- a/src/main/java/com/todoary/ms/src/web/dto/Token.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/Token.java
@@ -3,7 +3,9 @@ package com.todoary.ms.src.web.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
+@ToString
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/todoary/ms/src/web/dto/Token.java
+++ b/src/main/java/com/todoary/ms/src/web/dto/Token.java
@@ -1,14 +1,11 @@
 package com.todoary.ms.src.web.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @ToString
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
+@AllArgsConstructor @Builder
 public class Token {
     private String accessToken;
     private String refreshToken;

--- a/src/main/resources/templates/responses.html
+++ b/src/main/resources/templates/responses.html
@@ -1,0 +1,26 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Todoary Common Responses</title>
+</head>
+<body>
+    <div>
+        <table>
+            <thead>
+            <tr>
+                <th>isSuccess</th>
+                <th>code</th>
+                <th>message</th>
+            </tr>
+            </thead>
+            <tr th:each="response : ${responses}">
+                <td th:text="${response.isSuccess}"></td>
+                <td th:text="${response.code}"></td>
+                <td th:text="${response.message}"></td>
+            </tr>
+        </table>
+    </div>
+</body>
+

--- a/src/test/java/com/todoary/ms/src/service/AuthServiceTest.java
+++ b/src/test/java/com/todoary/ms/src/service/AuthServiceTest.java
@@ -54,7 +54,7 @@ class AuthServiceTest {
      * saveRefreshToken()
      */
     @Test
-    void refreshToken이_존재하는_멤버에게_새로_저장할_경우() throws NoSuchFieldException, InterruptedException {
+    void refreshToken이_존재하는_멤버에게_새로_저장할_경우() throws InterruptedException {
         // 멤버에게 새로운 refreshToken 저장
         Member member = createMemberHasRefreshToken();
         String beforeRefreshTokenCode = member.getRefreshToken().getCode();
@@ -62,7 +62,7 @@ class AuthServiceTest {
         // 추가로 refreshToken 저장
         // sleep하지 않으면 시간 차이가 얼마 나지 않아 refresh token 값이 같음 (밀리 세컨드 단위는 없어진다)
         Thread.sleep(1000);
-        RefreshToken found = authService.createRefreshToken(member);
+        RefreshToken found = authService.issueRefreshToken(member.getId());
         RefreshToken findRefreshToken = refreshTokenService.findByMemberId(member.getId());
 
         assertThat(beforeRefreshTokenCode).isNotEqualTo(findRefreshToken.getCode());
@@ -73,7 +73,7 @@ class AuthServiceTest {
     void refreshToken이_존재하지_않는_멤버에게_새로_저장할_경우() throws NoSuchFieldException {
         Member member = createMember();
 
-        authService.createRefreshToken(member);
+        authService.issueRefreshToken(member.getId());
         RefreshToken findRefreshToken = refreshTokenService.findByMemberId(member.getId());
 
         assertThat(member.getRefreshToken()).isEqualTo(findRefreshToken);
@@ -103,8 +103,8 @@ class AuthServiceTest {
         RefreshToken findRefreshToken = refreshTokenService.findByMemberId(member.getId());
 
         //when
-        AccessToken accessToken = authService.issueAccessToken(findRefreshToken.getCode());
-        RefreshToken refreshToken = authService.issueRefreshToken(findRefreshToken.getCode());
+        AccessToken accessToken = authService.issueAccessTokenFromRefreshTokenCode(findRefreshToken.getCode());
+        RefreshToken refreshToken = authService.issueRefreshTokenFromRefreshTokenCode(findRefreshToken.getCode());
 
         //then
         assertThat(authService.decodableAccessToken(accessToken.getCode(), member.getId())).isTrue();

--- a/src/test/java/com/todoary/ms/src/service/AuthServiceTest.java
+++ b/src/test/java/com/todoary/ms/src/service/AuthServiceTest.java
@@ -113,7 +113,7 @@ class AuthServiceTest {
 
     Member createMember() {
         MemberJoinParam memberJoinParam = createMemberJoinParam();
-        return memberService.findById(memberService.joinGeneralMember(memberJoinParam));
+        return memberService.findActiveMemberById(memberService.joinGeneralMember(memberJoinParam));
     }
 
     Member createMemberHasRefreshToken() {

--- a/src/test/java/com/todoary/ms/src/service/MemberServiceTest.java
+++ b/src/test/java/com/todoary/ms/src/service/MemberServiceTest.java
@@ -55,7 +55,7 @@ class MemberServiceTest {
         MemberJoinParam memberJoinParam = createMemberJoinParam();
         //when
         Long joinMemberId = memberService.joinGeneralMember(memberJoinParam);
-        Member member = memberService.findById(joinMemberId);
+        Member member = memberService.findActiveMemberById(joinMemberId);
         //then
         assertThat(member.getEmail()).isEqualTo(memberJoinParam.getEmail());
         assertThat(member.getProviderAccount()).isEqualTo(ProviderAccount.none());
@@ -93,11 +93,11 @@ class MemberServiceTest {
     void 같은_이메일_일반멤버_탈퇴했을때_재가입_O() {
         // given
         Long memberId = memberService.joinGeneralMember(createMemberJoinParam("nickname1", "email@email.com"));
-        memberService.findById(memberId).deactivate();
+        memberService.findActiveMemberById(memberId).deactivate();
         // when
         MemberJoinParam memberJoinParam = createMemberJoinParam("nickname2", "email@email.com");
         Long newMemberId = memberService.joinGeneralMember(memberJoinParam);
-        Member newMember = memberService.findById(newMemberId);
+        Member newMember = memberService.findActiveMemberById(newMemberId);
         // then
         assertThat(memberId).isNotEqualTo(newMemberId);
         assertThat(newMember.getNickname()).isEqualTo("nickname2");
@@ -107,14 +107,14 @@ class MemberServiceTest {
     void 같은_이메일_애플멤버_탈퇴했을때_재가입_O() {
         // given
         Long memberId = memberService.joinOauthMember(createOauthMemberJoinParamOfEmail("email@email.com"));
-        memberService.findById(memberId).deactivate();
+        memberService.findActiveMemberById(memberId).deactivate();
         // when
         Long newMemberId = memberService.joinOauthMember(createOauthMemberJoinParamOfEmail("email@email.com"));
-        Member newMember = memberService.findById(newMemberId);
+        Member newMember = memberService.findActiveMemberById(newMemberId);
         // then
         assertThat(memberId).isNotEqualTo(newMemberId);
         assertThat(newMember.getEmail()).isEqualTo("email@email.com");
-        assertThatThrownBy(() -> memberService.findById(memberId))
+        assertThatThrownBy(() -> memberService.findActiveMemberById(memberId))
                 .isInstanceOf(TodoaryException.class)
                 .matches(e -> ((TodoaryException) e).getStatus().equals(EMPTY_USER));
     }
@@ -169,7 +169,7 @@ class MemberServiceTest {
         MemberJoinParam memberJoinParam = createMemberJoinParam();
         Long joinMemberId = memberService.joinGeneralMember(memberJoinParam);
         // when
-        Member member = memberService.findById(joinMemberId);
+        Member member = memberService.findActiveMemberById(joinMemberId);
         // then
         assertThat(member.getId()).isEqualTo(joinMemberId);
         assertThat(member.isDeactivated()).isFalse();
@@ -179,7 +179,7 @@ class MemberServiceTest {
     void 멤버_조회시_id없을때_exception() {
         // given
         // when
-        ThrowingCallable action = () -> memberService.findById(10L);
+        ThrowingCallable action = () -> memberService.findActiveMemberById(10L);
         // then
         assertThatThrownBy(action)
                 .isInstanceOf(TodoaryException.class)
@@ -193,7 +193,7 @@ class MemberServiceTest {
         // when
         Long joinMemberId = memberService.joinGeneralMember(memberJoinParam);
         // then
-        List<Category> categories = memberService.findById(joinMemberId).getCategories();
+        List<Category> categories = memberService.findActiveMemberById(joinMemberId).getCategories();
         assertThat(categories).hasSize(1);
         assertThat(categories.get(0).getTitle()).isEqualTo(initialTitle);
         assertThat(categories.get(0).getColor()).isEqualTo(initialColor);
@@ -206,7 +206,7 @@ class MemberServiceTest {
         MemberJoinParam memberJoinParam = createMemberJoinParam();
         // when
         Long joinMemberId = memberService.joinGeneralMember(memberJoinParam);
-        String profileImgUrl = memberService.findById(joinMemberId).getProfileImgUrl();
+        String profileImgUrl = memberService.findActiveMemberById(joinMemberId).getProfileImgUrl();
         // then
         assertThat(profileImgUrl).isEqualTo(defaultProfileImageUrl);
     }
@@ -219,7 +219,7 @@ class MemberServiceTest {
         // when
         memberService.deactivateMember(joinMemberId);
         // then
-        assertThatThrownBy(() -> memberService.findById(joinMemberId))
+        assertThatThrownBy(() -> memberService.findActiveMemberById(joinMemberId))
                 .isInstanceOf(TodoaryException.class)
                 .matches(e -> ((TodoaryException) e).getStatus().equals(USERS_DELETED_USER));
     }
@@ -329,7 +329,7 @@ class MemberServiceTest {
         memberService.setProfileImgDefault(memberId);
 
         //then
-        assertThat(memberService.findById(memberId).getProfileImgUrl()).isEqualTo(defaultProfileImageUrl);
+        assertThat(memberService.findActiveMemberById(memberId).getProfileImgUrl()).isEqualTo(defaultProfileImageUrl);
     }
 
     @Test
@@ -348,7 +348,7 @@ class MemberServiceTest {
         memberService.setProfileImgDefault(member.getId());
 
         //then
-        Member findMember = memberService.findById(member.getId());
+        Member findMember = memberService.findActiveMemberById(member.getId());
         assertThat(findMember.getProfileImgUrl()).isEqualTo(defaultProfileImageUrl);
     }
 

--- a/src/test/java/com/todoary/ms/src/web/controller/AuthControllerTest.java
+++ b/src/test/java/com/todoary/ms/src/web/controller/AuthControllerTest.java
@@ -325,7 +325,7 @@ class AuthControllerTest {
 
     Member createMember() {
         MemberJoinParam memberJoinParam = createMemberJoinParam();
-        return memberService.findById(memberService.joinGeneralMember(memberJoinParam));
+        return memberService.findActiveMemberById(memberService.joinGeneralMember(memberJoinParam));
     }
 
     MemberJoinParam createMemberJoinParam() {

--- a/src/test/java/com/todoary/ms/src/web/controller/AuthControllerTest.java
+++ b/src/test/java/com/todoary/ms/src/web/controller/AuthControllerTest.java
@@ -53,8 +53,8 @@ class AuthControllerTest {
 
     @Test
     public void refreshToken_재발급_테스트() throws Exception {
-        when(authService.issueAccessToken(anyString())).thenReturn(new AccessToken("accessToken"));
-        when(authService.issueRefreshToken(anyString())).thenReturn(new RefreshToken(Member.builder().build(), "refreshToken"));
+        when(authService.issueAccessTokenFromRefreshTokenCode(anyString())).thenReturn(new AccessToken("accessToken"));
+        when(authService.issueRefreshTokenFromRefreshTokenCode(anyString())).thenReturn(new RefreshToken(Member.builder().build(), "refreshToken"));
 
         String requestBody = "{\"refreshToken\" : \"formalRefreshToken\"}";
         mockMvc.perform(

--- a/src/test/java/com/todoary/ms/src/web/controller/TodoControllerTest.java
+++ b/src/test/java/com/todoary/ms/src/web/controller/TodoControllerTest.java
@@ -63,7 +63,7 @@ class TodoControllerTest {
     void 투두_제목_최대_이하일때_생성O() throws Exception {
         // given
         Long expected = 1L;
-        given(todoService.saveTodo(any(), any())).willReturn(expected);
+        given(todoService.createMembersTodo(any(), any())).willReturn(expected);
 
         String title = "제목";
         TodoRequest requestDto = TodoRequest.builder()
@@ -177,7 +177,7 @@ class TodoControllerTest {
     void 투두_제목_최대_이하일때_수정O() throws Exception {
         // given
         Long expected = 1L;
-        given(todoService.saveTodo(any(), any())).willReturn(expected);
+        given(todoService.createMembersTodo(any(), any())).willReturn(expected);
 
         String title = "제목";
         TodoRequest requestDto = TodoRequest.builder()
@@ -206,7 +206,7 @@ class TodoControllerTest {
                 TodoResponse.builder().title("todo1").targetDate(targetDate).build(),
                 TodoResponse.builder().title("todo2").targetDate(targetDate).build()
         );
-        given(todoService.findTodosByDate(any(), eq(targetDate))).willReturn(expected);
+        given(todoService.retrieveMembersTodosOnDate(any(), eq(targetDate))).willReturn(expected);
         // when
         MvcResult result = mvc.perform(get(RETRIEVE_DATE, targetDate))
                 .andExpect(status().isOk())
@@ -243,7 +243,7 @@ class TodoControllerTest {
                 .targetTime(LocalTime.of(21, 40))
                 .isAlarmEnabled(true)
                 .build();
-        given(todoService.updateTodo(anyLong(), anyLong(), any()))
+        given(todoService.updateMembersTodo(anyLong(), anyLong(), any()))
                 .willReturn(TodoResponse.builder()
                                     .title("제목")
                                     .categoryId(10L)
@@ -298,7 +298,7 @@ class TodoControllerTest {
         // given
         willDoNothing()
                 .given(todoService)
-                .deleteTodo(any(), any());
+                .deleteMembersTodo(any(), any());
         // when
         MvcResult result = mvc.perform(delete(REQUEST_URL.DELETE, 1L).with(csrf()))
                 .andExpect(status().isOk())
@@ -315,7 +315,7 @@ class TodoControllerTest {
         // given
         willThrow(new TodoaryException(USERS_TODO_NOT_EXISTS))
                 .given(todoService)
-                .deleteTodo(any(), any());
+                .deleteMembersTodo(any(), any());
         // when
         MvcResult result = mvc.perform(delete(REQUEST_URL.DELETE, 1L).with(csrf()))
                 .andExpect(status().isOk())
@@ -335,7 +335,7 @@ class TodoControllerTest {
                 TodoResponse.builder().categoryId(categoryId).build(),
                 TodoResponse.builder().categoryId(categoryId).build()
         );
-        given(todoService.findTodosByCategory(any(), eq(categoryId))).willReturn(expected);
+        given(todoService.retrieveMembersTodosByCategory(any(), eq(categoryId))).willReturn(expected);
         // when
         MvcResult result = mvc.perform(get(RETRIEVE_CATEGORY, categoryId))
                 .andExpect(status().isOk())
@@ -519,7 +519,7 @@ class TodoControllerTest {
         // given
         YearMonth yearMonth = YearMonth.of(2023, 1);
         List<Integer> expected = List.of(1, 10);
-        given(todoService.findDaysHavingTodoInMonth(any(), eq(yearMonth))).willReturn(expected);
+        given(todoService.retrieveDaysHavingTodoOfMemberInMonth(any(), eq(yearMonth))).willReturn(expected);
         // when
         MvcResult result = mvc.perform(get(RETRIEVE_MONTH_DAYS, yearMonth))
                 .andExpect(status().isOk())

--- a/test-scripts/build.sh
+++ b/test-scripts/build.sh
@@ -2,7 +2,7 @@
 
 # set -e -o pipefail
 
-PROJECT_ROOT="/home/ubuntu/todoary/dev/project"
+PROJECT_ROOT="/home/ubuntu/todoary/test/project"
 
 #echo -e "\
 # +------------------------------------+

--- a/test-scripts/start.sh
+++ b/test-scripts/start.sh
@@ -5,8 +5,8 @@ echo -e "\
  |              3. start              |
  +------------------------------------+"
 
-PROJECT_ROOT="/home/ubuntu/todoary/dev/project"
-JAR_FILE="$PROJECT_ROOT/build/libs/todoary-0.0.1-SNAPSHOT.jar"
+PROJECT_ROOT="/home/ubuntu/todoary/test/project"
+JAR_FILE="$PROJECT_ROOT/build/libs/*.jar"
 
 APP_LOG="$PROJECT_ROOT/application.log"
 ERROR_LOG="$PROJECT_ROOT/error.log"
@@ -17,7 +17,7 @@ TIME_NOW=$(date +%c)
 # jar 파일 실행
 echo "$TIME_NOW > $JAR_FILE 파일 실행" | tee -a $DEPLOY_LOG
 nohup java -jar \
-  -Dspring.profiles.active=dev \
+  -Dspring.profiles.active=test-deploy \
   $JAR_FILE > $APP_LOG 2> $ERROR_LOG &
 
 CURRENT_PID=$(pgrep -f $JAR_FILE)

--- a/test-scripts/stop.sh
+++ b/test-scripts/stop.sh
@@ -5,15 +5,14 @@ echo -e "\
  |              2. stop               |
  +------------------------------------+"
 
-PROJECT_ROOT="/home/ubuntu/Test-Todoary-Server"
-JAR_FILE="$PROJECT_ROOT/build/libs/todoary-0.0.1-SNAPSHOT.jar"
+PROJECT_ROOT="/home/ubuntu/todoary/test/project"
 
 DEPLOY_LOG="$PROJECT_ROOT/deploy.log"
 
 TIME_NOW=$(date +%c)
 
 # 현재 구동 중인 애플리케이션 pid 확인
-CURRENT_PID=$(pgrep -f $JAR_FILE)
+CURRENT_PID=$(pgrep -f active=test-deploy)
 
 # 프로세스가 켜져 있으면 종료
 if [ -z $CURRENT_PID ]; then


### PR DESCRIPTION
## What is this PR? 🔍
- 프로필 기본 이미지 파일 새로 PM님께 받아서 submodule 업데이트했습니다.
- 일반 멤버일땐 이메일, 소셜 멤버일땐 ProviderAccount 정보로만 검사하도록 했습니다. 소셜 멤버의 이메일은 계속 변경되므로 이메일로 비교해선 안됩니다. (관련 로직은 추가해놨었는데 반영이 안됐네요..)
- 원래 탈퇴한 유저면 액세스토큰 발급하면 안되지만 프론트엔드에서 복구 시에 추가 api 전송 없이 바로 토큰 사용할 수 있도록 토큰 발급합니다. 만약 복구 대신 새로 회원가입하면 해당 토큰은 사용할 수 없습니다. (멤버 id가 변경되므로)
  - 기존에 멤버에서 findById는 모두 findActiveMemberById로 변경하고 탈퇴한 유저도 상관없이 조회하는 findById를 추가했습니다.
- 앱 런칭 넣으면서 Release 브랜치 CI/CD 워크플로우도 수정하고, Release 브랜치에 v1.0.0으로 커밋했습니다. 이번엔 꼭 리젝 안받길...
- 위와 같은 맥락으로 복구 대신 새로 회원가입했을 때도 바로 토큰 응답하여 로그인 api 추가로 사용하지 않고 바로 로그인할 수 있도록 했습니다.

## To Reviewers 📢
- 소셜 멤버일때 이메일로 조회하는 곳 없나 한번씩 확인해주세요~!
- 소셜일 때랑 일반일때를 계속 구분하는 게 중복되는 로직이 마음에 안들어서 인터페이스나 추상클래스로 상위 클래스 만들고 소셜/일반을 하위 클래스로 구현해서 사용하는 게 나을 것 같아 그렇게 수정해보려고 하다가 JPA랑 엮인 문제라 쉽지 않네요... 그래서 일단은 놔뒀고 런칭 성공하면 그 때 한번 수정해보면 좋을 것 같아요
