### PR TITLE
fix: 소셜 멤버 비교 시 이메일 없이 Provider Account 정보로만 비교한다

### DIFF
--- a/src/test/java/com/todoary/ms/src/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/todoary/ms/src/repository/MemberRepositoryTest.java
@@ -43,7 +43,7 @@ class MemberRepositoryTest {
         memberRepository.save(member);
 
         //when
-        Boolean result = memberRepository.isProviderAccountAndEmailUsed(providerAccount, "member@member");
+        Boolean result = memberRepository.isEmailOfGeneralMemberUsed("member@member");
 
         //then
         assertThat(result).isTrue();
@@ -63,7 +63,7 @@ class MemberRepositoryTest {
         memberRepository.save(member);
 
         //when
-        Boolean result = memberRepository.isProviderAccountAndEmailUsed(providerAccount, "member2@member");
+        Boolean result = memberRepository.isEmailOfGeneralMemberUsed("member2@member");
 
         //then
         assertThat(result).isFalse();


### PR DESCRIPTION
## What is this PR? 🔍
- 소셜 멤버 비교 시 이메일도 같이 비교했던 게 계속 남아있네요 추가로 수정했습니다
