### PR TITLE
fix: 소셜 멤버 비교 시 이메일 없이 Provider Account 정보로만 비교한다

### DIFF
--- a/src/test/java/com/todoary/ms/src/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/todoary/ms/src/repository/MemberRepositoryTest.java
@@ -32,18 +32,17 @@ class MemberRepositoryTest {
     @Test
     public void 멤버를_이메일과_provider로_검색_유저_존재O() throws Exception {
         //given
-        ProviderAccount providerAccount = createProviderAccount();
         Member member = Member.builder()
                 .name("memberA")
                 .email("member@member")
-                .providerAccount(providerAccount)
+                .providerAccount(ProviderAccount.appleFrom("test.1234"))
                 .isTermsEnable(true)
                 .build();
 
         memberRepository.save(member);
 
         //when
-        Boolean result = memberRepository.isProviderAccountAndEmailUsed(providerAccount, "member@member");
+        Boolean result = memberRepository.isProviderAccountUsed(ProviderAccount.appleFrom("test.1234"));
 
         //then
         assertThat(result).isTrue();
@@ -63,7 +62,7 @@ class MemberRepositoryTest {
         memberRepository.save(member);
 
         //when
-        Boolean result = memberRepository.isProviderAccountAndEmailUsed(providerAccount, "member2@member");
+        Boolean result = memberRepository.isEmailOfGeneralMemberUsed("member2@member");
 
         //then
         assertThat(result).isFalse();


### PR DESCRIPTION
## What is this PR? 🔍
- 소셜 멤버 비교 시 이메일도 같이 비교했던 게 계속 남아있네요 추가로 수정했습니다

