### PR TITLE
fix: 카테고리 수정 후 투두 삭제되는 버그 해결한다

### DIFF
--- a/src/main/java/com/todoary/ms/src/domain/Todo.java
+++ b/src/main/java/com/todoary/ms/src/domain/Todo.java
@@ -56,9 +56,6 @@ public class Todo extends BaseTimeEntity {
     }
 
     private void setCategory(Category category) {
-        if (this.category != null){
-            this.category.getTodos().remove(this);
-        }
         this.category = category;
         category.addTodo(this);
     }

--- a/src/main/java/com/todoary/ms/src/web/controller/TodoController.java
+++ b/src/main/java/com/todoary/ms/src/web/controller/TodoController.java
@@ -111,7 +111,7 @@ public class TodoController {
 
     // 3.9 투두 알람 수정
     @PatchMapping("/{todoId}/alarm")
-    public BaseResponse<BaseResponseStatus> modifyTodoAlram(
+    public BaseResponse<BaseResponseStatus> modifyTodoAlaram(
             @LoginMember Long memberId,
             @PathVariable("todoId") Long todoId,
             @RequestBody @Valid TodoAlarmRequest request

--- a/src/test/java/com/todoary/ms/src/service/TodoServiceTest.java
+++ b/src/test/java/com/todoary/ms/src/service/TodoServiceTest.java
@@ -101,7 +101,7 @@ class TodoServiceTest {
         assertThat(todo.getTargetDate()).isEqualTo(expectedDate);
         assertThat(todo.getTargetTime()).isEqualTo(expectedTime);
         assertThat(todo.getCategory()).isEqualTo(expectedCategory);
-        assertThat(category.getTodos()).isEmpty();
+        assertThat(todoService.retrieveMembersTodosByCategory(member.getId(), category.getId())).isEmpty();
         assertThat(expectedCategory.getTodos()).contains(todo);
     }
 


### PR DESCRIPTION
## What is this PR? 🔍
- 투두 수정 시 카테고리 수정하면 투두가 삭제되는 버그 해결

## To Reviewers 📢
- 투두 수정 시 카테고리 수정하면 투두가 삭제되는 버그가 있었는데.. 카테고리 연관관계 세팅할 때 remove하는 부분때문에 삭제된 것 같습니다. (수정된 코드 확인하시면 어디 말하는지 알거에요)
- 근데 remove를 안하면 트랜잭션 끝나기 전엔 카테고리의 투두 목록엔 반영이 안되는데 어차피 트랜잭션 안에서 다시 조회할 일 없으니까 상관없는 걸까요? 🤔 테스트 코드가 있었는데 안잡혀서 몰랐네요 .. 
- 저희 삭제할 때 연관관계 반대쪽에서 remove하는 코드가 많은데 여기도 다 수정해야 할까요?
